### PR TITLE
Keep USWDS banner collapsed after logout

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -9,7 +9,7 @@
         </em>
       </div>
       <% if user_signed_in? %>
-        <%= link_to "Logout #{current_user["uid"]}", logout_path, class: "usa-button" %>
+        <%= link_to "Logout #{current_user["uid"]}", logout_path, class: "usa-button", data: {turbolinks: false} %>
       <% else %>
         <%= button_to "Login", "/auth/hses", class: "usa-button" %>
       <% end %>


### PR DESCRIPTION
## Description of change

Previously, the USWDS banner would expand after the user logs out, instead of remaining collapsed.

After this change, the USWDS banner remains collapsed until the user expands it.

## How to test

1. Login with an HSES user account
2. Logout
3. Verify that the USWDS banner remains collapsed

## Issue(s)

* closes #43 


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Project board status updated
- [ ] Code is meaningfully tested
  - no current tests around UI like this.
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [ ] Boundary diagram updated
  - boundary diagram doesnt yet exist
- [x] Logical Data Model updated
- [x] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
