### PR TITLE
Complaints fake data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem "omniauth", "~> 2.0"
 gem "omniauth-oauth2", "~> 1.7"
 gem "omniauth-rails_csrf_protection", "~> 1.0"
 
+# Use ffaker for faked connections to HSES data
+gem "ffaker", "~> 2.18"
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
+    ffaker (2.18.0)
     ffi (1.15.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -278,6 +279,7 @@ DEPENDENCIES
   brakeman (~> 5.1)
   bundler-audit (~> 0.8)
   byebug
+  ffaker (~> 2.18)
   jbuilder (~> 2.7)
   listen (~> 3.3)
   omniauth (~> 2.0)

--- a/app/controllers/complaints_controller.rb
+++ b/app/controllers/complaints_controller.rb
@@ -1,4 +1,5 @@
 class ComplaintsController < ApplicationController
   def index
+    @complaints = FakeData::Complaints.generate_response
   end
 end

--- a/app/controllers/complaints_controller.rb
+++ b/app/controllers/complaints_controller.rb
@@ -1,5 +1,5 @@
 class ComplaintsController < ApplicationController
   def index
-    @complaints = FakeData::Complaints.generate_response
+    @complaints = FakeData::Complaints.generate_response[:data]
   end
 end

--- a/app/lib/fake_data/complaints.rb
+++ b/app/lib/fake_data/complaints.rb
@@ -1,0 +1,73 @@
+require "ffaker"
+
+module FakeData::Complaints
+  def self.data
+    {
+      id: FFaker::Random.rand(9999).to_s,
+      type: "issues",
+      attributes: {
+        issueLastUpdated: FFaker::Time.date,
+        creationDate: FFaker::Time.date,
+        closedDate: FFaker::Time.date,
+        reopenedDate: FFaker::Time.date,
+        initialContactDate: FFaker::Time.date,
+        type: FFaker::Random.rand(2),
+        otherType: FFaker::Lorem.word,
+        issue: FFaker::Lorem.phrase,
+        priority: FFaker::Random.rand(3),
+        status: FFaker::Random.rand(3),
+        dueDate: FFaker::Time.date,
+        # these just sound cool for use as the grantee name :)
+        grantee: FFaker::AddressUK.street_name
+      },
+      relationships: {
+        grantAward: {
+          meta: {
+            id: FFaker::Random.rand(9999).to_s
+          }
+        },
+        grantProgram: {
+          meta: {
+            id: FFaker::Random.rand(999).to_s
+          }
+        },
+        region: {
+          meta: {
+            id: FFaker::Random.rand(10).to_s
+          }
+        }
+      },
+      links: {
+        self: "https://example.com/TODO",
+        html: "https://example.com/TODO"
+      }
+    }
+  end
+
+  def self.generate_response
+    json = jsonapi_wrapper
+    25.times do |item|
+      json[:data] << data
+    end
+    json
+  end
+
+  def self.jsonapi_wrapper
+    {
+      meta: {
+        pageNumber: 1,
+        pageSize: 25,
+        pageTotalCount: 1,
+        itemTotalCount: 25
+      },
+      data: [],
+      links: {
+        self: "https://example.com/TODO",
+        first: "https://example.com/TODO",
+        last: "https://example.com/TODO",
+        prev: "https://example.com/TODO",
+        next: "https://example.com/TODO"
+      }
+    }
+  end
+end

--- a/app/lib/fake_data/complaints.rb
+++ b/app/lib/fake_data/complaints.rb
@@ -3,14 +3,14 @@ require "ffaker"
 module FakeData::Complaints
   def self.data
     {
-      id: FFaker::Random.rand(9999).to_s,
+      id: identifier,
       type: "issues",
       attributes: {
-        issueLastUpdated: FFaker::Time.date,
-        creationDate: FFaker::Time.date,
-        closedDate: FFaker::Time.date,
-        reopenedDate: FFaker::Time.date,
-        initialContactDate: FFaker::Time.date,
+        issueLastUpdated: datetime,
+        creationDate: datetime,
+        closedDate: datetime,
+        reopenedDate: datetime,
+        initialContactDate: datetime,
         type: FFaker::Random.rand(2),
         otherType: FFaker::Lorem.word,
         issue: FFaker::Lorem.phrase,
@@ -23,17 +23,17 @@ module FakeData::Complaints
       relationships: {
         grantAward: {
           meta: {
-            id: FFaker::Random.rand(9999).to_s
+            id: identifier
           }
         },
         grantProgram: {
           meta: {
-            id: FFaker::Random.rand(999).to_s
+            id: identifier
           }
         },
         region: {
           meta: {
-            id: FFaker::Random.rand(10).to_s
+            id: identifier
           }
         }
       },
@@ -42,6 +42,17 @@ module FakeData::Complaints
         html: "https://example.com/TODO"
       }
     }
+  end
+
+  def self.datetime
+    faketime = FFaker::Time.datetime
+    # format UTC date YYYY-MM-DDTHH:MM:SSZ
+    faketime.strftime("%FT%TZ")
+  end
+
+  # returns a string because actual identifiers may not be integers
+  def self.identifier
+    FFaker::Random.rand(9999).to_s
   end
 
   def self.generate_response

--- a/spec/lib/fake_data/complaints_spec.rb
+++ b/spec/lib/fake_data/complaints_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe FakeData::Complaints do
       complaint = FakeData::Complaints.data
 
       expect(complaint[:id]).to_not be_nil
+      expect(complaint[:id]).to be_a(String)
       expect(complaint[:attributes]).to be_a(Hash)
       expect(complaint.dig(:relationships, :grantAward, :meta, :id)).to be_a(String)
       expect(complaint[:links]).to be_a(Hash)
@@ -15,20 +16,17 @@ RSpec.describe FakeData::Complaints do
   describe "datetime" do
     it "returns a string formatted as ISO-8601 UTC datetime" do
       dt = FakeData::Complaints.datetime
+
       expect(dt).to be_a(String)
-      begin
-        expect(Time.iso8601(dt)).to be_a(Time)
-      rescue
-        expect(false).to be_truthy
-      end
+      expect(Time.iso8601(dt)).to be_a(Time)
     end
   end
 
   describe "identifier" do
-    it "returns a string of numbers" do
+    it "returns a string" do
       id = FakeData::Complaints.identifier
+
       expect(id).to be_a(String)
-      expect(id.to_i.to_s).to eq(id)
     end
   end
 

--- a/spec/lib/fake_data/complaints_spec.rb
+++ b/spec/lib/fake_data/complaints_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe FakeData::Complaints do
+  describe "jsonapi_wrapper" do
+    it "returns an object with JSON-API top level JSON API" do
+      wrapper = FakeData::Complaints.jsonapi_wrapper
+
+      expect(wrapper[:meta]).to be_a(Hash)
+      expect(wrapper[:data]).to be_a(Array)
+      expect(wrapper[:links]).to be_a(Hash)
+    end
+  end
+
+  describe "complaint_data" do
+    it "returns a single complaint object" do
+      complaint = FakeData::Complaints.data
+
+      expect(complaint[:id]).to_not be_nil
+      expect(complaint[:attributes]).to be_a(Hash)
+      expect(complaint.dig(:relationships, :grantAward, :meta, :id)).to be_a(String)
+      expect(complaint[:links]).to be_a(Hash)
+    end
+  end
+
+  describe "generate_response" do
+    it "returns a JSON-API object with 25 complaints" do
+      res = FakeData::Complaints.generate_response
+
+      expect(res[:data].length).to eq(25)
+    end
+  end
+end

--- a/spec/lib/fake_data/complaints_spec.rb
+++ b/spec/lib/fake_data/complaints_spec.rb
@@ -1,16 +1,6 @@
 require "rails_helper"
 
 RSpec.describe FakeData::Complaints do
-  describe "jsonapi_wrapper" do
-    it "returns an object with JSON-API top level JSON API" do
-      wrapper = FakeData::Complaints.jsonapi_wrapper
-
-      expect(wrapper[:meta]).to be_a(Hash)
-      expect(wrapper[:data]).to be_a(Array)
-      expect(wrapper[:links]).to be_a(Hash)
-    end
-  end
-
   describe "complaint_data" do
     it "returns a single complaint object" do
       complaint = FakeData::Complaints.data
@@ -22,11 +12,41 @@ RSpec.describe FakeData::Complaints do
     end
   end
 
+  describe "datetime" do
+    it "returns a string formatted as ISO-8601 UTC datetime" do
+      dt = FakeData::Complaints.datetime
+      expect(dt).to be_a(String)
+      begin
+        expect(Time.iso8601(dt)).to be_a(Time)
+      rescue
+        expect(false).to be_truthy
+      end
+    end
+  end
+
+  describe "identifier" do
+    it "returns a string of numbers" do
+      id = FakeData::Complaints.identifier
+      expect(id).to be_a(String)
+      expect(id.to_i.to_s).to eq(id)
+    end
+  end
+
   describe "generate_response" do
     it "returns a JSON-API object with 25 complaints" do
       res = FakeData::Complaints.generate_response
 
       expect(res[:data].length).to eq(25)
+    end
+  end
+
+  describe "jsonapi_wrapper" do
+    it "returns an object with JSON-API top level JSON API" do
+      wrapper = FakeData::Complaints.jsonapi_wrapper
+
+      expect(wrapper[:meta]).to be_a(Hash)
+      expect(wrapper[:data]).to be_a(Array)
+      expect(wrapper[:links]).to be_a(Hash)
     end
   end
 end


### PR DESCRIPTION
## Description of change

Adds mocked in data imitating future HSES response
Addresses: https://github.com/OHS-Hosting-Infrastructure/complaint-tracker/issues/49

## Acceptance Criteria

- [ ] fake JSON data is created which matches parameters of #21
- [ ] data can be accessed from a controller

## How to test

`rails spec` runs a couple cursory tests which check the basic structure of the data being created

If you want to look at the data being generated, you can add `<%= @complaints.to_json %>` to `app/views/complaints/index.html.erb`

## Issue(s)

- closes #49


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Project board status updated
  - moved to "in progress"
- [ ] Code is meaningfully tested
  - for reviewers: do you think this is enough testing?
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- ~[ ] API Documentation updated~
- ~[ ] Boundary diagram updated~
- ~[ ] Logical Data Model updated~
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions
  - for reviewers: should I make an ADR explaining why we went with ffaker instead of the staging export data?

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
