### PR TITLE
increases header size to 31.2px

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -2,7 +2,7 @@
   <div class="grid-container">
     <div class="grid-row">
       <div class="usa-logo grid-col-6" id="basic-logo">
-        <em class="usa-logo__text">
+        <em class="usa-logo__text font-heading-xl">
             OHS Complaint Tracker
         </em>
       </div>


### PR DESCRIPTION
## Description of change

Increases the font size of the text in the header to meet #62 

## Acceptance Criteria

The font size of the header is closer to 32 than it is to 22.

## How to test

Check out the branch, inspect the text in the header, check in the computed CSS

## Issue(s)

* closes #62

## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Project board status updated
- [ ] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- ~API Documentation updated~
- ~Boundary diagram updated~
- ~Logical Data Model updated~
- ~[Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

## To the Reviewer

I have questions:

- Is it okay that the page's `<h1>` is 39px?
- Is that USWDS class the best one to apply to accomplish this?

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
