### PR TITLE
Ensure pa11y scans fail the build when they fail

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -63,15 +63,20 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://complaint_tracker:postgres@localhost:5432/complaint_tracker_test
-        run: yarn run pa11y-ci 2>&1 | tee pa11y_output.txt
+        shell: bash
+        run: |
+          set -o pipefail
+          yarn run pa11y-ci 2>&1 | tee pa11y_output.txt
 
       - name: Read pa11y_output file.
+        if: ${{ failure() }}
         id: pa11y_output
         uses: juliangruber/read-file-action@v1
         with:
           path: ./pa11y_output.txt
 
       - name: Comment on pull request.
+        if: ${{ failure() }}
         uses: thollander/actions-comment-pull-request@master
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -81,9 +86,3 @@ jobs:
 
               ```${{ steps.pa11y_output.outputs.content }}```
             </details>
-
-      - name: Check for pa11y failures.
-        if: contains(steps.pa11y_output.outputs.content, 'errno 2')
-        run: |
-          echo "::error::The site is failing accessibility tests. Please review the comment in the pull request or the pa11y-ci step in the workflow for details."
-          exit 1


### PR DESCRIPTION
## Description of change

* Get error code for pa11y scan directly from the exit status code instead of parsing the output
* Only comment on PRs when the scan fails.

Paired with @jduss4 for this work


## Acceptance Criteria

* A failing scan causes the build status to be failed, and outputs the information to a PR comment
* A passing scan does not add a PR comment.

## How to test

Check CI/CD output

## Issue(s)

* closes #55 


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Project board status updated
- [x] Code is meaningfully tested
~- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)~
No UI changes
~- [ ] API Documentation updated~
No APIs updated
~- [ ] Boundary diagram updated~
No boundary updates
~- [ ] Logical Data Model updated~
LDM doesn't yet exist
~- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~
no major decisions made

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
