### PR TITLE
displays message confirming log out

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,6 +10,7 @@ class SessionsController < ApplicationController
 
   def destroy
     reset_session
+    flash[:notice] = "You are now logged out"
     redirect_to root_path
   end
 

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,0 +1,18 @@
+<% if flash[:notice] %>
+  <div class="usa-alert usa-alert--success usa-alert--slim">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+        <%= flash[:notice] %>
+      </p>
+    </div>
+  </div>
+<% end %>
+<% if flash[:error] %>
+  <div class="usa-alert usa-alert--error usa-alert--slim">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+        <%= flash[:error] %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
     <main class="usa-layout-docs usa-section" id="main-content">
       <div class="grid-container">
         <div class="usa-layout-docs__main usa-prose">
+          <%= render "layouts/flash_messages" %>
           <%= yield %>
         </div>
       </div>

--- a/spec/requests/complaints_spec.rb
+++ b/spec/requests/complaints_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe "Complaints", type: :request do
       end
     end
 
+    describe "on log out" do
+      it "displays a message that user was logged out" do
+        delete logout_path
+        follow_redirect!
+        expect(response.body).to include("You are now logged out")
+      end
+    end
+
     describe "with an authorized user" do
       let(:user) {
         {

--- a/spec/views/application/_flash_messages.html.erb_spec.rb
+++ b/spec/views/application/_flash_messages.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "rendering flash_messages" do
+  it "matches a notice message" do
+    flash[:notice] = "Testing flash notice"
+    render partial: "layouts/flash_messages"
+
+    expect(rendered).to match "Testing flash notice"
+    expect(rendered).to match "usa-alert--success"
+  end
+
+  it "matches an error message" do
+    flash[:error] = "Testing error notice"
+    render partial: "layouts/flash_messages"
+
+    expect(rendered).to match "Testing error notice"
+    expect(rendered).to match "usa-alert--error"
+  end
+
+  it "matches a notice and error message" do
+    flash[:notice] = "Testing flash notice"
+    flash[:error] = "Testing error notice"
+    render partial: "layouts/flash_messages"
+
+    expect(rendered).to match "Testing flash notice"
+    expect(rendered).to match "Testing error notice"
+  end
+
+  it "displays nothing if there are no messages" do
+    render partial: "layouts/flash_messages"
+
+    expect(rendered).to eq ""
+  end
+end


### PR DESCRIPTION
## Description of change

Displays a message to the user after logging out. Adds flash notice / error to layout for future use.

![image](https://user-images.githubusercontent.com/2480492/129736162-1af9d5db-77c9-433e-976f-1d688e444b18.png)

## Acceptance Criteria

## How to test

Log in, then log out. You should see a message in green with a checkbox near the top of the page confirming you are now logged out.

## Issue(s)

* closes #51


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Project board status updated
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- ~API Documentation updated~
- ~Boundary diagram updated~
- ~Logical Data Model updated~
- ~Architectural Decision Records~

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
