### PR TITLE
Pa11y scan for logged in pages

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Start up rails server in the background
         env:
           RAILS_ENV: test
+          BYPASS_AUTH: true
           DATABASE_URL: postgres://complaint_tracker:postgres@localhost:5432/complaint_tracker_test
         run: |
           bundle exec rails server &

--- a/.pa11yci
+++ b/.pa11yci
@@ -5,6 +5,7 @@
     "runners": ["axe"]
   },
   "urls": [
-    "http://localhost:8080"
+    "http://localhost:8080",
+    "http://localhost:8080/complaints"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ visibility into status and actions taken to address a complaint.
 The Complaint Tracker is utilizing the HSES Staging environment for non-production authentication. If you need an account
 reach out in the [#ph-ohs-oneteam](https://gsa-tts.slack.com/archives/C01TT2YNX0R) Slack channel for help in requesting one.
 
+##### Bypassing HSES Authentication
+
+When `RAILS_ENV` is either `test` or `development` you can bypass authentication by setting the `BYPASS_AUTH` environment variable to `true`.
+
+When bypassing auth, you may use `CURRENT_USER_UID` and/or `CURRENT_USER_NAME` to override the current user's HSES name or username.
+
 Consider [setting up automatic linting and testing](#set-up-automatic-linting-and-testing) while you're at it!
 
 ### Running Tests

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,12 +2,24 @@ class ApplicationController < ActionController::Base
   private
 
   def require_user!
-    unless helpers.user_signed_in?
-      redirect_to root_path, alert: "You must log in first"
-    end
+    return if helpers.user_signed_in?
+    return if bypass_local_auth?
+    redirect_to root_path, alert: "You must log in first"
   end
 
   def user_root_path
     complaints_path
+  end
+
+  def bypass_local_auth?
+    return false if Rails.env.production?
+    if ENV["BYPASS_AUTH"] == "true"
+      session["user"] ||= {
+        uid: ENV.fetch("CURRENT_USER_UID", "1"),
+        name: ENV.fetch("CURRENT_USER_NAME", "Fake Test-User")
+      }.with_indifferent_access
+      return true
+    end
+    false
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  private
+  before_action :require_user!
 
   def require_user!
     return if helpers.user_signed_in?
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
     return false if Rails.env.production?
     if ENV["BYPASS_AUTH"] == "true"
       session["user"] ||= {
-        uid: ENV.fetch("CURRENT_USER_UID", "1"),
+        uid: ENV.fetch("CURRENT_USER_UID", "fake.testuser@test.com"),
         name: ENV.fetch("CURRENT_USER_NAME", "Fake Test-User")
       }.with_indifferent_access
       return true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,13 @@
 class ApplicationController < ActionController::Base
+  private
+
+  def require_user!
+    unless helpers.user_signed_in?
+      redirect_to root_path, alert: "You must log in first"
+    end
+  end
+
+  def user_root_path
+    complaints_path
+  end
 end

--- a/app/controllers/complaints_controller.rb
+++ b/app/controllers/complaints_controller.rb
@@ -1,4 +1,6 @@
 class ComplaintsController < ApplicationController
+  before_action :require_user!
+
   def index
     @complaints = FakeData::ApiResponse.generate_hses_issues_response[:data]
   end

--- a/app/controllers/complaints_controller.rb
+++ b/app/controllers/complaints_controller.rb
@@ -1,6 +1,4 @@
 class ComplaintsController < ApplicationController
-  before_action :require_user!
-
   def index
     @complaints = FakeData::ApiResponse.generate_hses_issues_response[:data]
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,7 @@
+class PagesController < ApplicationController
+  def welcome
+    if helpers.user_signed_in?
+      redirect_to user_root_path
+    end
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  skip_before_action :require_user!
+
   def welcome
     if helpers.user_signed_in?
       redirect_to user_root_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < ApplicationController
     session["user"] = {
       uid: auth_info["uid"],
       name: auth_info["info"]["name"]
-    }
+    }.with_indifferent_access
     Rails.logger.debug { "Got auth_info: #{JSON.pretty_generate(auth_info)}" }
     redirect_to user_root_path
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :require_user!
+
   def create
     session["user"] = {
       uid: auth_info["uid"],

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < ApplicationController
       name: auth_info["info"]["name"]
     }
     Rails.logger.debug { "Got auth_info: #{JSON.pretty_generate(auth_info)}" }
-    redirect_to root_path
+    redirect_to user_root_path
   end
 
   def destroy

--- a/app/views/complaints/index.html.erb
+++ b/app/views/complaints/index.html.erb
@@ -1,6 +1,2 @@
 <h1>Complaints List</h1>
-<% if user_signed_in? %>
-   <%= render (@complaints.empty? ? 'no_complaints_alert' : 'complaints_table') %>
-<% else %>
-  <div>Please log in to access your complaints list</div>
-<% end %>
+<%= render (@complaints.empty? ? 'no_complaints_alert' : 'complaints_table') %>

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -7,11 +7,11 @@
     </div>
   </div>
 <% end %>
-<% if flash[:error] %>
+<% if flash[:alert] %>
   <div class="usa-alert usa-alert--error usa-alert--slim">
     <div class="usa-alert__body">
       <p class="usa-alert__text">
-        <%= flash[:error] %>
+        <%= flash[:alert] %>
       </p>
     </div>
   </div>

--- a/app/views/pages/welcome.html.erb
+++ b/app/views/pages/welcome.html.erb
@@ -1,0 +1,2 @@
+<h1>Welcome</h1>
+<p>Please log in to access your complaints list</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  get "/", to: "complaints#index", as: :root
+  resources :complaints, only: :index
 
+  # session pages
   get "/oauth2-client/login/oauth2/code/", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"
+
+  root to: "pages#welcome"
 end

--- a/spec/requests/complaints_spec.rb
+++ b/spec/requests/complaints_spec.rb
@@ -1,15 +1,16 @@
 require "rails_helper"
 
 RSpec.describe "Complaints", type: :request do
-  describe "GET /index" do
-    it "returns a 200 status" do
-      get root_path
-      expect(response).to have_http_status(200)
+  describe "GET /complaints" do
+    it "returns a 302 status" do
+      get complaints_path
+      expect(response).to have_http_status(302)
     end
 
     describe "without an authorized user" do
       it "asks the user to log" do
-        get root_path
+        get complaints_path
+        follow_redirect!
         expect(response.body).to include("Please log in to access your complaints list")
       end
     end
@@ -36,8 +37,13 @@ RSpec.describe "Complaints", type: :request do
         allow_any_instance_of(ActionDispatch::Request::Session).to receive(:[]).with("user").and_return user
       end
 
+      it "returns a 200 status" do
+        get complaints_path
+        expect(response).to have_http_status(200)
+      end
+
       it "includes the user's name" do
-        get root_path
+        get complaints_path
         expect(response.body).to include user["name"].to_s
       end
 
@@ -46,7 +52,7 @@ RSpec.describe "Complaints", type: :request do
 
         it "includes the alert" do
           allow(FakeData::ApiResponse).to receive(:generate_hses_issues_response).and_return data: [complaint.data]
-          get root_path
+          get complaints_path
 
           expect(response.body).to include '<table class="usa-table">'
         end
@@ -56,7 +62,7 @@ RSpec.describe "Complaints", type: :request do
         it "includes the alert" do
           allow(FakeData::ApiResponse).to receive(:generate_hses_issues_response).and_return data: []
 
-          get root_path
+          get complaints_path
           expect(response.body).to include user["name"].to_s
           expect(response.body).to include '<h3 class="usa-alert__heading">No issues found</h3>'
         end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "Pages", type: :request do
+  describe "GET /" do
+    it "returns http success" do
+      get "/"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -2,9 +2,31 @@ require "rails_helper"
 
 RSpec.describe "Pages", type: :request do
   describe "GET /" do
-    it "returns http success" do
-      get "/"
-      expect(response).to have_http_status(:success)
+    context "user is not logged in" do
+      it "returns http success" do
+        get root_path
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "user is logged in" do
+      let(:user) {
+        {
+          name: "Request Spec",
+          uid: "request.spec@test.com"
+        }.with_indifferent_access
+      }
+
+      before do
+        # There are some other session requests before getting to session["user"]
+        allow_any_instance_of(ActionDispatch::Request::Session).to receive(:[])
+        allow_any_instance_of(ActionDispatch::Request::Session).to receive(:[]).with("user").and_return user
+      end
+
+      it "redirects to the complaints list" do
+        get root_path
+        expect(response).to redirect_to(complaints_path)
+      end
     end
   end
 end

--- a/spec/views/application/_flash_messages.html.erb_spec.rb
+++ b/spec/views/application/_flash_messages.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "rendering flash_messages" do
   end
 
   it "matches an error message" do
-    flash[:error] = "Testing error notice"
+    flash[:alert] = "Testing error notice"
     render partial: "layouts/flash_messages"
 
     expect(rendered).to match "Testing error notice"
@@ -19,7 +19,7 @@ RSpec.describe "rendering flash_messages" do
 
   it "matches a notice and error message" do
     flash[:notice] = "Testing flash notice"
-    flash[:error] = "Testing error notice"
+    flash[:alert] = "Testing error notice"
     render partial: "layouts/flash_messages"
 
     expect(rendered).to match "Testing flash notice"


### PR DESCRIPTION
## Description of change

* Enables setting a `BYPASS_AUTH` flag to allow pa11y to scan the complaints table

## Acceptance Criteria

Given I'm running a pa11y scan
When an error is in place on the complaint table
Then the scan should fail

## How to test

1. Update one of the table cells in `_complaints_table.html.erb` to have `style="color: #eee;"`
2. Run the server with `RAILS_ENV=test BYPASS_AUTH=true bundle exec rails server`
3. Run pa11y with: `yarn run pa11y-ci`

You should see color contrast failures on http://localhost:8080/complaints

## Issue(s)

* closes #76 
* closes #8 I think, since this can be used in any non-production environment. It doesn't quite pass the AC there though


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Project board status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [x] API Documentation updated
- [x] Boundary diagram updated
- [x] Logical Data Model updated
- [x] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
