### PR TITLE
Adds class variable to controller to persist fake issues data

### DIFF
--- a/app/controllers/complaints_controller.rb
+++ b/app/controllers/complaints_controller.rb
@@ -1,7 +1,5 @@
 class ComplaintsController < ApplicationController
-  @@hses_issues = FakeData::ApiResponse.generate_hses_issues_response[:data]
-
   def index
-    @complaints = @@hses_issues
+    @complaints = FakeData::ApiResponse.hses_issues_response[:data]
   end
 end

--- a/app/controllers/complaints_controller.rb
+++ b/app/controllers/complaints_controller.rb
@@ -1,5 +1,7 @@
 class ComplaintsController < ApplicationController
+  @@hses_issues = FakeData::ApiResponse.generate_hses_issues_response[:data]
+
   def index
-    @complaints = FakeData::ApiResponse.generate_hses_issues_response[:data]
+    @complaints = @@hses_issues
   end
 end

--- a/app/models/fake_data/api_response.rb
+++ b/app/models/fake_data/api_response.rb
@@ -4,6 +4,10 @@ class FakeData::ApiResponse
     jsonapi_wrapper.merge(data: complaints)
   end
 
+  def self.hses_issues_response
+    @issues_response ||= generate_hses_issues_response
+  end
+
   def self.jsonapi_wrapper
     {
       meta: {

--- a/spec/models/api_response_spec.rb
+++ b/spec/models/api_response_spec.rb
@@ -1,11 +1,20 @@
 require "rails_helper"
 
 RSpec.describe FakeData::ApiResponse do
-  describe "generate_response" do
+  describe "generate_hses_issues_response" do
     it "returns a JSON-API object with 25 complaints" do
       res = FakeData::ApiResponse.generate_hses_issues_response
 
       expect(res[:data].length).to eq(25)
+    end
+  end
+
+  describe "hses_issues_response" do
+    it "returns JSON-API object with persistent complaints" do
+      res1 = FakeData::ApiResponse.hses_issues_response[:data].first
+      res2 = FakeData::ApiResponse.hses_issues_response[:data].first
+
+      expect(res1).to eq(res2)
     end
   end
 

--- a/spec/requests/complaints_spec.rb
+++ b/spec/requests/complaints_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe "Complaints", type: :request do
       end
 
       describe "User has no complaints" do
+        before { ComplaintsController.class_variable_set :@@hses_issues, [] }
         it "includes the alert" do
           allow(FakeData::ApiResponse).to receive(:generate_hses_issues_response).and_return data: []
-
           get complaints_path
           expect(response.body).to include user["name"].to_s
           expect(response.body).to include '<h3 class="usa-alert__heading">No issues found</h3>'

--- a/spec/requests/complaints_spec.rb
+++ b/spec/requests/complaints_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Complaints", type: :request do
         let(:complaint) { FakeData::Complaint.new }
 
         it "includes the alert" do
-          allow(FakeData::ApiResponse).to receive(:generate_hses_issues_response).and_return data: [complaint.data]
+          allow(FakeData::ApiResponse).to receive(:hses_issues_response).and_return data: [complaint.data]
           get complaints_path
 
           expect(response.body).to include '<table class="usa-table">'
@@ -59,9 +59,8 @@ RSpec.describe "Complaints", type: :request do
       end
 
       describe "User has no complaints" do
-        before { ComplaintsController.class_variable_set :@@hses_issues, [] }
         it "includes the alert" do
-          allow(FakeData::ApiResponse).to receive(:generate_hses_issues_response).and_return data: []
+          allow(FakeData::ApiResponse).to receive(:hses_issues_response).and_return data: []
           get complaints_path
           expect(response.body).to include user["name"].to_s
           expect(response.body).to include '<h3 class="usa-alert__heading">No issues found</h3>'


### PR DESCRIPTION
## Description of change

Adds a class variable to the ComplaintsController which contains the fake data. This way, the fake data will not change when the user refreshes the page or navigates between (future) complaints pages.

## Acceptance Criteria

The fake data does not change on every request or between users, just on app reload.

## How to test

Manually, can start up the app and refresh the index page a few times to verify that the fake data is not changing. In terms of how to test the data is persistent in rspec, I am seeking advice.

## Issue(s)

* closes https://github.com/OHS-Hosting-Infrastructure/complaint-tracker/issues/79


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Project board status updated
- [x] Code is meaningfully tested
- ~Meets accessibility standards (WCAG 2.1 Levels A, AA)~
- ~API Documentation updated~
- ~Boundary diagram updated~
- ~Logical Data Model updated~
- ~[Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
