### PR TITLE
adds CC0 license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+As a work of the United States government, this project is in the public domain within the United States.
+
+Additionally, we waive copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication.
+
+## CC0 1.0 Universal summary
+
+This is a human-readable summary of the [Legal Code (read the full text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+### No copyright
+
+The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.
+
+### Other information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.

--- a/doc/adr/0005-license.md
+++ b/doc/adr/0005-license.md
@@ -1,0 +1,19 @@
+# 5. License
+
+Date: 2021-08-19
+
+## Status
+
+Accepted
+
+## Context
+
+This software should have a license which articulates how it may be used and modified, as well as what rights the authors may claim.
+
+## Decision
+
+We will use a CC 1.0 Universal public domain license. This is because [nearly all works created by the U.S. Government](https://www.usa.gov/government-works) are copyright-free.
+
+## Consequences
+
+Since this repository is in the public domain, we need to consider the licensing terms before incorporating contents whose rights would conflict with this resource's license. In that case, we will need to modify our license to make it clear that it does not apply to all of the contents of the repository.


### PR DESCRIPTION
## Description of change

Adds a CC0 (public domain) license. I took this directly from the license used by the (deprecated) [18F open source styleguide](https://github.com/18F/open-source-guide/blob/18f-pages/LICENSE.md).

## Acceptance Criteria

`LICENSE.md` explains the terms of our license and links out to the CC0 legal text

## How to test

Look at `LICENSE.md`, I guess

## Issue(s)

* closes https://github.com/OHS-Hosting-Infrastructure/complaint-tracker/issues/67


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Project board status updated
- ~[Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
