### PR TITLE
Add sortable complaint status

### DIFF
--- a/app/helpers/complaints_helper.rb
+++ b/app/helpers/complaints_helper.rb
@@ -1,0 +1,27 @@
+module ComplaintsHelper
+  FORMATTED_STATUS = {
+    0 => "In Progress",
+    1 => "Closed",
+    2 => "Rec. Closure",
+    3 => "Rec. Reopening",
+    4 => "Reopened"
+  }
+
+  STATUS_SORT_ORDER = {
+    "New" => 0,
+    "Rec. Reopening" => 1,
+    "Reopened" => 2,
+    "In Progress" => 3,
+    "Rec. Closure" => 4,
+    "Closed" => 5
+  }
+
+  def status(complaint_attributes)
+    formatted_status = FORMATTED_STATUS[complaint_attributes[:status]]
+    if complaint_attributes[:creationDate] > 1.week.ago && formatted_status == "In Progress"
+      "New"
+    else
+      formatted_status
+    end
+  end
+end

--- a/app/models/fake_data/complaint.rb
+++ b/app/models/fake_data/complaint.rb
@@ -16,7 +16,7 @@ class FakeData::Complaint
         otherType: word,
         issue: phrase,
         priority: random_int,
-        status: random_int,
+        status: random_int(4),
         dueDate: date,
         grantee: grantee_name
       },

--- a/app/views/complaints/_complaints_table.html.erb
+++ b/app/views/complaints/_complaints_table.html.erb
@@ -17,24 +17,7 @@
     </thead>
     <tbody>
     <% @complaints.each do |complaint| %>
-      <tr>
-        <th scope="row" role="rowheader"><%= complaint[:id] %></th>
-        <td 
-          data-sort-value="<%= DateTime.parse(complaint[:attributes][:creationDate]).to_i %>"
-        >
-          <%= DateTime.parse(complaint[:attributes][:creationDate]).strftime("%m/%d/%Y") %>
-        </td>
-        <% formatted_status = status(complaint[:attributes]) %>
-        <td
-         data-sort-value="<%= ComplaintsHelper::STATUS_SORT_ORDER[formatted_status] %>"
-        >
-          <%= formatted_status %>
-        </td>
-        <td><%= complaint[:attributes][:grantee] %></td>
-        <td><%= truncate(complaint[:attributes][:issue]) %></td>
-        <td> TBD </td>
-        <td> TBD </td>
-      </tr>
+     <%= render 'complaints/complaints_table_detail', :complaint => complaint %> 
     <% end %>
     </tbody>
   </table>

--- a/app/views/complaints/_complaints_table.html.erb
+++ b/app/views/complaints/_complaints_table.html.erb
@@ -8,7 +8,7 @@
           scope="col"
           role="columnheader"
         > Date Created </th>
-        <th scope="col" role="columnheader"> Status </th>
+        <th data-sortable scope="col" role="columnheader"> Status </th>
         <th scope="col" role="columnheader"> Grantee </th>
         <th scope="col" role="columnheader"> Issue </th>
         <th scope="col" role="columnheader"> TTA </th>
@@ -24,7 +24,12 @@
         >
           <%= DateTime.parse(complaint[:attributes][:creationDate]).strftime("%m/%d/%Y") %>
         </td>
-        <td>TBD</td>
+        <% formatted_status = status(complaint[:attributes]) %>
+        <td
+         data-sort-value="<%= ComplaintsHelper::STATUS_SORT_ORDER[formatted_status] %>"
+        >
+          <%= formatted_status %>
+        </td>
         <td><%= complaint[:attributes][:grantee] %></td>
         <td><%= truncate(complaint[:attributes][:issue]) %></td>
         <td> TBD </td>

--- a/app/views/complaints/_complaints_table_detail.html.erb
+++ b/app/views/complaints/_complaints_table_detail.html.erb
@@ -1,0 +1,22 @@
+<tr>
+  <% formatted_status = status(complaint[:attributes]) %>
+  <th scope="row" role="rowheader">
+    <span class="<%= formatted_status == "New" ? "text-bold" : "" %>">
+      <%= complaint[:id] %>
+    </span>
+  </th>
+  <td 
+    data-sort-value="<%= DateTime.parse(complaint[:attributes][:creationDate]).to_i %>"
+  >
+    <%= DateTime.parse(complaint[:attributes][:creationDate]).strftime("%m/%d/%Y") %>
+  </td>
+  <td
+    data-sort-value="<%= ComplaintsHelper::STATUS_SORT_ORDER[formatted_status] %>"
+  >
+    <%= formatted_status %>
+  </td>
+  <td><%= complaint[:attributes][:grantee] %></td>
+  <td><%= truncate(complaint[:attributes][:issue]) %></td>
+  <td> TBD </td>
+  <td> TBD </td>
+</tr>

--- a/spec/helpers/complaints_helper_spec.rb
+++ b/spec/helpers/complaints_helper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ComplaintsHelper, type: :helper do
         end
       end
     end
-    
+
     describe "a complaint that is more than a week old" do
       let(:complaint) { {status: 0, creationDate: 1.month.ago} }
 

--- a/spec/helpers/complaints_helper_spec.rb
+++ b/spec/helpers/complaints_helper_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe ComplaintsHelper, type: :helper do
+  describe "#status" do
+    describe "a complaint that is less than a week old" do
+      let(:complaint) { {status: 0, creationDate: 1.day.ago} }
+
+      describe "an open complaint" do
+        it "returns 'New' as the formatted status" do
+          expect(status(complaint)).to eq "New"
+        end
+      end
+
+      describe "a complaint that is not open" do
+        it "returns the formatted status of the complaint's status " do
+          complaint[:status] = 3
+          expect(status(complaint)).to eq ComplaintsHelper::FORMATTED_STATUS[3]
+        end
+      end
+    end
+    
+    describe "a complaint that is more than a week old" do
+      let(:complaint) { {status: 0, creationDate: 1.month.ago} }
+
+      describe "an open complaint" do
+        it "returns 'In Progress' as the formatted status" do
+          expect(status(complaint)).to eq "In Progress"
+        end
+      end
+
+      describe "a complaint that is not open" do
+        it "returns the formatted status of the complaint's status " do
+          complaint[:status] = 2
+          expect(status(complaint)).to eq ComplaintsHelper::FORMATTED_STATUS[2]
+        end
+      end
+    end
+  end
+end

--- a/spec/views/complaints/_complaints_table.html.erb_spec.rb
+++ b/spec/views/complaints/_complaints_table.html.erb_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "rendering complaints table" do
   let(:complaint) { FakeData::Complaint.new.data }
   it "has a table to display complaints" do
     @complaints = [complaint]
+
     render partial: "complaints/complaints_table"
 
     expect(rendered).to match '<table class="usa-table">'

--- a/spec/views/complaints/_complaints_table_detail.html.erb_spec.rb
+++ b/spec/views/complaints/_complaints_table_detail.html.erb_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "rendering complaints table" do
+  let(:complaint) { FakeData::Complaint.new.data }
+  describe "a new complaint" do
+    it "has a bold id" do
+      complaint[:attributes][:creationDate] = 1.day.ago.strftime("%FT%TZ")
+      complaint[:attributes][:status] = 0
+      complaint[:id] = "12345"
+
+      render partial: "complaints/complaints_table_detail", locals: {complaint: complaint}
+      expect(rendered.squish).to match '<span class="text-bold"> 12345 </span>'
+    end
+  end
+
+  describe "an older complaint" do
+    it "does not have a bold id" do
+      complaint[:attributes][:creationDate] = 1.month.ago.strftime("%FT%TZ")
+      complaint[:id] = "12345"
+
+      render partial: "complaints/complaints_table_detail", locals: {complaint: complaint}
+      expect(rendered.squish).to match '<span class=""> 12345 </span>'
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

This change adds the formatted status to the complaints table view.
It also creates a sort order as described in the linked issue so a user can sort based on status. (So new complaints rise to the top)

## Acceptance Criteria
Given that I am a Program Specialist
When I click on the status column of my complaints list
Then I see the status of complaints listed in the status column as:

"New"
"Rec. Reopening"
"Reopened"
"In Progress"
"Rec. Closure"
"Closed"

## How to test
- [ ] log into complaints tracker
- [ ] click on the "status" column
- [ ] complaints should be grouped and sorted by the above order

note: this PR does not address the colors that might be mentioned in #71 -- those have been separated out into #81

## Issue(s)

* closes #71 


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Project board status updated
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
