### PR TITLE
expands upon log out message to explain HSES status

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,9 @@ class SessionsController < ApplicationController
 
   def destroy
     reset_session
-    flash[:notice] = "You are now logged out"
+    msg = "You are now logged out of the complaints tracker."
+    msg += "<br><em>Note: you may still be logged in to HSES</em>"
+    flash[:notice] = msg
     redirect_to root_path
   end
 

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -2,7 +2,7 @@
   <div class="usa-alert usa-alert--success usa-alert--slim">
     <div class="usa-alert__body">
       <p class="usa-alert__text">
-        <%= flash[:notice] %>
+        <%= sanitize flash[:notice] %>
       </p>
     </div>
   </div>
@@ -11,7 +11,7 @@
   <div class="usa-alert usa-alert--error usa-alert--slim">
     <div class="usa-alert__body">
       <p class="usa-alert__text">
-        <%= flash[:alert] %>
+        <%= sanitize flash[:alert] %>
       </p>
     </div>
   </div>

--- a/spec/requests/complaints_spec.rb
+++ b/spec/requests/complaints_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Complaints", type: :request do
       it "displays a message that user was logged out" do
         delete logout_path
         follow_redirect!
-        expect(response.body).to include("You are now logged out")
+        expect(response.body).to include("You are now logged out of the complaints tracker.<br><em>Note: you may still be logged in to HSES</em>")
       end
     end
 


### PR DESCRIPTION
## Description of change

Implements Laura's design for log out notice which alerts user to discrepancy between login status of complaints tracker vs HSES

## Acceptance Criteria

Message with new text appears to user with return line and italics on logout

![image](https://user-images.githubusercontent.com/2480492/131388053-7271a265-080b-4546-9b32-bcf3568514a8.png)

## How to test

Run app locally. Log in or BYPASS_AUTH, then click log out button. You should see message towards top of the screen.

## Issue(s)

* closes https://github.com/OHS-Hosting-Infrastructure/complaint-tracker/issues/69


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Project board status updated
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- ~API Documentation updated~
- ~Boundary diagram updated~
- ~Logical Data Model updated~
- ~[Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
