### PR TITLE
Terraform actions

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -22,8 +22,8 @@ jobs:
         uses: tj-actions/changed-files@v1.1.2
         with:
           files: |
-            terraform/shared/**
-            terraform/stage/**
+            terraform/shared
+            terraform/stage
 
       - name: Terraform apply
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -17,18 +17,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Deploy app
-        uses: 18F/cg-deploy-action@main
-        env:
-          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          HSES_AUTH_CLIENT_SECRET: ${{ secrets.HSES_AUTH_CLIENT_SECRET }}
-        with:
-          cf_username: ${{ secrets.CF_USERNAME }}
-          cf_password: ${{ secrets.CF_PASSWORD }}
-          cf_org: hhs-acf-ohs-hses
-          cf_space: ct-stage
-          push_arguments: "--vars-file config/deployment/stage.yml --var rails_master_key=$RAILS_MASTER_KEY --var hses_auth_client_secret=$HSES_AUTH_CLIENT_SECRET"
-
       - name: Check for changes to Terraform
         id: changed-files
         uses: tj-actions/changed-files@v1.1.2
@@ -46,3 +34,15 @@ jobs:
           TF_VAR_cf_user: ${{ secrets.CF_USERNAME }}
           TF_VAR_cf_password: ${{ secrets.CF_PASSWORD }}
         run: terraform apply -auto-approve -input=false
+
+      - name: Deploy app
+        uses: 18F/cg-deploy-action@main
+        env:
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          HSES_AUTH_CLIENT_SECRET: ${{ secrets.HSES_AUTH_CLIENT_SECRET }}
+        with:
+          cf_username: ${{ secrets.CF_USERNAME }}
+          cf_password: ${{ secrets.CF_PASSWORD }}
+          cf_org: hhs-acf-ohs-hses
+          cf_space: ct-stage
+          push_arguments: "--vars-file config/deployment/stage.yml --var rails_master_key=$RAILS_MASTER_KEY --var hses_auth_client_secret=$HSES_AUTH_CLIENT_SECRET"

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -14,6 +14,8 @@ jobs:
     environment: stage
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Deploy app
         uses: 18F/cg-deploy-action@main
@@ -26,3 +28,21 @@ jobs:
           cf_org: hhs-acf-ohs-hses
           cf_space: ct-stage
           push_arguments: "--vars-file config/deployment/stage.yml --var rails_master_key=$RAILS_MASTER_KEY --var hses_auth_client_secret=$HSES_AUTH_CLIENT_SECRET"
+
+      - name: Check for changes to Terraform
+        id: changed-files
+        uses: tj-actions/changed-files@v1.1.2
+        with:
+          files: |
+            terraform/shared/**
+            terraform/stage/**
+
+      - name: Terraform apply
+        if: steps.changed-files.outputs.any_changed == 'true'
+        working-directory: terraform/stage
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
+          TF_VAR_cf_user: ${{ secrets.CF_USERNAME }}
+          TF_VAR_cf_password: ${{ secrets.CF_PASSWORD }}
+        run: terraform apply -auto-approve -input=false

--- a/.github/workflows/terraform-stage.yml
+++ b/.github/workflows/terraform-stage.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Read Terraform plan output file
         id: terraform_output
         uses: juliangruber/read-file-action@v1
+        if: ${{ always() }}
         with:
           path: ./terraform/stage/plan_output.txt
 
@@ -73,7 +74,3 @@ jobs:
               repo: context.repo.repo,
               body: output
             })
-
-      - name: Terraform plan status
-        if: ${{ always() }} && steps.plan.outcome == 'failure'
-        run: exit 1

--- a/.github/workflows/terraform-stage.yml
+++ b/.github/workflows/terraform-stage.yml
@@ -1,0 +1,81 @@
+name: Run Terraform in staging
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'terraform/**' ]
+  pull_request:
+    branches: [ main ]
+    paths: [ 'terraform/**' ]
+
+defaults:
+  run:
+    working-directory: terraform/stage
+
+jobs:
+  terraform:
+    name: Terraform
+    runs-on: ubuntu-latest
+    environment: stage
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
+      TF_VAR_cf_user: ${{ secrets.CF_USERNAME }}
+      TF_VAR_cf_password: ${{ secrets.CF_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Terraform format
+        id: format
+        run: terraform fmt -check
+
+      - name: Terraform init
+        id: init
+        run: terraform init
+
+      - name: Terraform validate
+        id: validation
+        run: terraform validate -no-color
+
+      - name: Terraform plan
+        id: plan
+        if: github.event_name == 'pull_request'
+        run: terraform plan -no-color -input=false
+
+      # inspiration: https://learn.hashicorp.com/tutorials/terraform/github-actions#review-actions-workflow
+      - name: Update PR
+        uses: actions/github-script@v4
+        # we would like to update the PR even when a prior step failed
+        if: ${{ always() }} && github.event_name == 'pull_request'
+        with:
+          script: |
+            const output = `Terraform Format and Style: ${{ steps.format.outcome }}
+            Terraform Initialization: ${{ steps.init.outcome }}
+            Terraform Validation: ${{ steps.validation.outcome }}
+            Terraform Plan: ${{ steps.plan.outcome }}
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`\n
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Terraform plan status
+        if: github.event_name == 'pull_request' && steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Terraform apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -auto-approve -input=false

--- a/.github/workflows/terraform-stage.yml
+++ b/.github/workflows/terraform-stage.yml
@@ -41,7 +41,14 @@ jobs:
       - name: Terraform plan
         id: plan
         if: github.event_name == 'pull_request'
-        run: terraform plan -no-color -input=false
+        run: terraform plan -no-color -input=false 2>&1 | tee plan_output.txt
+
+      - name: Read Terraform plan output file
+        if: github.event_name == 'pull_request'
+        id: terraform_output
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./terraform/stage/plan_output.txt
 
       # inspiration: https://learn.hashicorp.com/tutorials/terraform/github-actions#review-actions-workflow
       - name: Update PR
@@ -58,7 +65,7 @@ jobs:
             <details><summary>Show Plan</summary>
 
             \`\`\`\n
-            ${{ steps.plan.outputs.stdout }}
+            ${{ steps.terraform_output.outputs.content }}
             \`\`\`
 
             </details>

--- a/.github/workflows/terraform-stage.yml
+++ b/.github/workflows/terraform-stage.yml
@@ -1,9 +1,6 @@
 name: Run Terraform in staging
 
 on:
-  push:
-    branches: [ main ]
-    paths: [ 'terraform/**' ]
   pull_request:
     branches: [ main ]
     paths: [ 'terraform/**' ]
@@ -40,11 +37,9 @@ jobs:
 
       - name: Terraform plan
         id: plan
-        if: github.event_name == 'pull_request'
         run: terraform plan -no-color -input=false 2>&1 | tee plan_output.txt
 
       - name: Read Terraform plan output file
-        if: github.event_name == 'pull_request'
         id: terraform_output
         uses: juliangruber/read-file-action@v1
         with:
@@ -54,7 +49,7 @@ jobs:
       - name: Update PR
         uses: actions/github-script@v4
         # we would like to update the PR even when a prior step failed
-        if: ${{ always() }} && github.event_name == 'pull_request'
+        if: ${{ always() }}
         with:
           script: |
             const output = `Terraform Format and Style: ${{ steps.format.outcome }}
@@ -80,9 +75,5 @@ jobs:
             })
 
       - name: Terraform plan status
-        if: github.event_name == 'pull_request' && steps.plan.outcome == 'failure'
+        if: ${{ always() }} && steps.plan.outcome == 'failure'
         run: exit 1
-
-      - name: Terraform apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: terraform apply -auto-approve -input=false

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,6 +2,8 @@
 
 ## Set up a new environment
 
+The below steps rely on you first configuring access to the Terraform state in s3 as described in [Terraform State Credentials](#terraform-state-credentials).
+
 1. Set up a service key
     ```bash
     # login
@@ -27,7 +29,7 @@
     cf_password = "password"
     ```
 
-1. Run terraform with
+1. Run terraform from your new environment directory with
     ```bash
     terraform init
     terraform plan
@@ -119,12 +121,11 @@ region = us-gov-west-1
 output = json
 ```
 
-2. Add the following to `~/.aws/credentials`
+2. You will need to set the following environment variables:
 
 ```
-[ct-terraform]
-aws_access_key_id = <<access_key_id from bucket_credentials or cf service-key>>
-aws_secret_access_key = <<secret_access_key from bucket_credentials or cf service-key>>
+export AWS_ACCESS_KEY_ID=<<access_key_id from bucket_credentials or cf service-key>>
+export AWS_SECRET_ACCESS_KEY=<<secret_access_key from bucket_credentials or cf service-key>>
 ```
 
 3. Copy `bucket` from `terraform` or `cf service-key` output to the backend block of `<env>/providers.tf`

--- a/terraform/stage/providers.tf
+++ b/terraform/stage/providers.tf
@@ -15,6 +15,5 @@ terraform {
     key     = "terraform.tfstate.stage"
     encrypt = "true"
     region  = "us-gov-west-1"
-    profile = "ct-terraform"
   }
 }


### PR DESCRIPTION
## Description of change

Creates 2 GitHub Action jobs:
- runs `terraform plan` when a PR to the main branch is opened, and outputs the results of `terraform plan` to a comment. Should fail if `terraform plan` fails
- runs `terraform apply` when changes to the terraform staging and shared directories are made and pushed to the main branch

At least I hope that's what happens, because I don't know how to test the second one.

## Acceptance Criteria

- `terraform plan` outputs content to a PR issue
- `terraform apply` runs successfully on main branch (not sure how to test this?)

## How to test

Great question!  I don't recommend the `act` library, unfortunately. I've tested manually here, so hopefully this PR getting a successful comment is enough evidence for the first goal of this PR.

## Issue(s)

* closes https://github.com/OHS-Hosting-Infrastructure/complaint-tracker/issues/92


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Project board status updated
- [NO] Code is meaningfully tested
- ~[ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)~
- ~[ ] API Documentation updated~
- ~[ ] Boundary diagram updated~
- ~[ ] Logical Data Model updated~
- ~[ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
