### PR TITLE
fixes fake data on complaints page

### DIFF
--- a/app/helpers/complaints_helper.rb
+++ b/app/helpers/complaints_helper.rb
@@ -17,7 +17,7 @@ module ComplaintsHelper
   }
 
   def status(complaint_attributes)
-    formatted_status = FORMATTED_STATUS[complaint_attributes[:status]]
+    formatted_status = FORMATTED_STATUS[complaint_attributes[:status][:id]]
     if complaint_attributes[:creationDate] > 1.week.ago && formatted_status == "In Progress"
       "New"
     else

--- a/app/views/complaints/_complaints_table.html.erb
+++ b/app/views/complaints/_complaints_table.html.erb
@@ -10,7 +10,7 @@
         > Date Created </th>
         <th data-sortable scope="col" role="columnheader"> Status </th>
         <th scope="col" role="columnheader"> Grantee </th>
-        <th scope="col" role="columnheader"> Issue </th>
+        <th scope="col" role="columnheader"> Summary </th>
         <th scope="col" role="columnheader"> TTA </th>
         <th scope="col" role="columnheader"> RAN </th>
       </tr>

--- a/app/views/complaints/_complaints_table_detail.html.erb
+++ b/app/views/complaints/_complaints_table_detail.html.erb
@@ -16,7 +16,7 @@
     <%= formatted_status %>
   </td>
   <td><%= complaint[:attributes][:grantee] %></td>
-  <td><%= truncate(complaint[:attributes][:issue]) %></td>
+  <td><%= truncate(complaint[:attributes][:summary]) %></td>
   <td> TBD </td>
   <td> TBD </td>
 </tr>

--- a/spec/helpers/complaints_helper_spec.rb
+++ b/spec/helpers/complaints_helper_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ComplaintsHelper, type: :helper do
   describe "#status" do
     describe "a complaint that is less than a week old" do
-      let(:complaint) { {status: 0, creationDate: 1.day.ago} }
+      let(:complaint) { {status: {id: 0}, creationDate: 1.day.ago} }
 
       describe "an open complaint" do
         it "returns 'New' as the formatted status" do
@@ -13,14 +13,14 @@ RSpec.describe ComplaintsHelper, type: :helper do
 
       describe "a complaint that is not open" do
         it "returns the formatted status of the complaint's status " do
-          complaint[:status] = 3
+          complaint[:status] = {id: 3}
           expect(status(complaint)).to eq ComplaintsHelper::FORMATTED_STATUS[3]
         end
       end
     end
 
     describe "a complaint that is more than a week old" do
-      let(:complaint) { {status: 0, creationDate: 1.month.ago} }
+      let(:complaint) { {status: {id: 0}, creationDate: 1.month.ago} }
 
       describe "an open complaint" do
         it "returns 'In Progress' as the formatted status" do
@@ -30,7 +30,7 @@ RSpec.describe ComplaintsHelper, type: :helper do
 
       describe "a complaint that is not open" do
         it "returns the formatted status of the complaint's status " do
-          complaint[:status] = 2
+          complaint[:status] = {id: 2}
           expect(status(complaint)).to eq ComplaintsHelper::FORMATTED_STATUS[2]
         end
       end

--- a/spec/views/complaints/_complaints_table_detail.html.erb_spec.rb
+++ b/spec/views/complaints/_complaints_table_detail.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "rendering complaints table" do
   describe "a new complaint" do
     it "has a bold id" do
       complaint[:attributes][:creationDate] = 1.day.ago.strftime("%FT%TZ")
-      complaint[:attributes][:status] = 0
+      complaint[:attributes][:status] = {id: 0}
       complaint[:id] = "12345"
 
       render partial: "complaints/complaints_table_detail", locals: {complaint: complaint}


### PR DESCRIPTION


## Description of change

The fake data structure changed, but the frontend wasn't adapted to fit it (my bad), so summary and status fell off the UI. This fixes that, by grabbing the identifier from the fake data's status and changing the name "issue" -> "summary".

The FORMATTED_STATUS does not match the labels in the HSES response, but that is expected, and we prefer the formatted status labels. For this reason, I am not passing the fake data's status label straight through to the user.

## Acceptance Criteria

You can view status and summary on the complaints index page.

## How to test

Fire up rails and check out the complaints page.

## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- ~[ ] No issue created~
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
