### PR TITLE
swaps out ci environment so it will use fake data

### DIFF
--- a/app/models/api.rb
+++ b/app/models/api.rb
@@ -20,6 +20,6 @@ class Api
   end
 
   def self.needs_fake_data?
-    Rails.env.development? || Rails.env.test?
+    Rails.env.development? || Rails.env.test? || Rails.env.ci?
   end
 end

--- a/config/environments/ci.rb
+++ b/config/environments/ci.rb
@@ -9,4 +9,9 @@ Rails.application.configure do
   config.logger = ActiveSupport::TaggedLogging.new(logger)
 
   config.x.bypass_auth = true
+
+  # override settings for production which are not used for ci
+  config.x.hses.auth_base = nil
+  config.x.hses.client_id = nil
+  config.x.hses.client_secret = nil
 end

--- a/spec/models/api_spec.rb
+++ b/spec/models/api_spec.rb
@@ -97,4 +97,21 @@ RSpec.describe Api do
       ).to eq Api::Testsystem::Endpoint
     end
   end
+
+  describe "in a ci environment" do
+    before do
+      allow(Rails).to receive(:env) { "ci".inquiry }
+    end
+
+    it "returns the test request" do
+      result = Api.request("testsystem", "endpoint")
+      expect(result).to eq "test request"
+    end
+
+    it "returns the full class" do
+      expect(
+        Api.namespaced_class("Testsystem", "Endpoint")
+      ).to eq Api::FakeData::Testsystem::Endpoint
+    end
+  end
 end


### PR DESCRIPTION
## Description of change

Prevents `ci` environment from using any HSES endpoints / auth for staging information. This is for the following reasons:
- HSES would not recognize the IP of a request sent during the CI process
- Tools like pa11y do not need real data at this point to function

## Acceptance Criteria

- application functions in `ci` environment and uses fake data

## How to test

Start app with `RAILS_ENV=ci rails s` to confirm

## Issue(s)

* closes https://github.com/OHS-Hosting-Infrastructure/complaint-tracker/issues/136

## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Code is meaningfully tested
- ~Meets accessibility standards (WCAG 2.1 Levels A, AA)~
- ~API Documentation updated~
- ~Boundary diagram updated~
- ~Logical Data Model updated~
- ~[Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions~

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
