### PR TITLE
Update Date.today to Date.current to prevent timezone issues

### DIFF
--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -27,13 +27,13 @@ class Complaint
   end
 
   def overdue?
-    due_date? && due_date.past?
+    due_date? && due_date.before?(Date.current)
   end
 
   def relative_due_date_html
     if overdue?
       "<span class=\"ct-timeline__overdue\">Overdue (Due #{formatted_due_date})</span>"
-    elsif due_date == Date.today
+    elsif due_date == Date.current
       "<span class=\"ct-timeline__due-soon\">Due today (#{formatted_due_date})</span>"
     elsif due_soon?
       "<span class=\"ct-timeline__due-soon\">Due in #{day_string} (#{formatted_due_date})</span>"
@@ -63,6 +63,6 @@ class Complaint
   end
 
   def relative_time_til_due
-    (Date.today...due_date).count
+    (Date.current...due_date).count
   end
 end

--- a/spec/models/complaint_spec.rb
+++ b/spec/models/complaint_spec.rb
@@ -98,11 +98,10 @@ RSpec.describe Complaint do
 
   describe "relative_due_date_html" do
     context "due today" do
-      before { subject.attributes[:dueDate] = Date.today.to_date.iso8601 }
+      before { subject.attributes[:dueDate] = Date.current.to_date.iso8601 }
 
       it "returns the correct html string" do
-        strftime = Date.today.strftime("%m/%d/%Y")
-
+        strftime = Date.current.strftime("%m/%d/%Y")
         expect(subject.relative_due_date_html).to eq(
           "<span class=\"ct-timeline__due-soon\">Due today (#{strftime})</span>"
         )


### PR DESCRIPTION
## Description of change
This change addresses a bug where we were using Date.today instead of Date.current -- this often leads to hard-to-find bugs, and did indeed! 

Bug resources:
https://thoughtbot.com/blog/its-about-time-zones

## How to test
Navigate to a complaint with a due date that is upcoming
Change your computer time zone and time to be later than midnight that day UTC. (So PT -- 5pm, ET -- 8PM)
Refresh the complaint
The due date should not change.

## Issue(s)

* closes #185 

## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code is meaningfully tested
Note: I couldn't figure out a good way to test this more deeply! Setting the local time via https://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html did not seem to work as expected. Would love any thoughts on how to make this work. (Although the tests did fail appropriately -- it was a bug)

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
