### PR TITLE
Ensure we can access the session user details

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def current_user
-    @current_user ||= session[:user]
+    @current_user ||= session[:user]&.with_indifferent_access
   end
 
   def user_signed_in?

--- a/app/models/api/hses.rb
+++ b/app/models/api/hses.rb
@@ -36,7 +36,7 @@ class Api::Hses::Issues < ApiRequest
   PAGE_LIMIT = 25
 
   def initialize(user:, params: {})
-    @username = user[:uid]
+    @username = user["uid"]
     @page = params[:page] || 1
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     it "returns the username" do
       session["user"] = session_user
-      expect(helper.current_user).to eq session_user
+      expect(helper.current_user).to eq session_user.with_indifferent_access
     end
   end
 


### PR DESCRIPTION
## Description of change

Nested hashes in `session` have only string keys by default when reloaded from the cookie. This change ensures that we can access the data we need

Paired with @jduss4 on the solution.

## Acceptance Criteria

Before the change: complaints were not loading from HSES staging
After the change: complaints are loading from HSES staging


## Issue(s)

* closes #199 


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
