### PR TITLE
changes table detail to use complaint model and adds RAN / TTA activity

### DIFF
--- a/app/helpers/complaints_helper.rb
+++ b/app/helpers/complaints_helper.rb
@@ -1,14 +1,6 @@
 module ComplaintsHelper
   include Pagy::Frontend
 
-  FORMATTED_STATUS = {
-    0 => "In Progress",
-    1 => "Closed",
-    2 => "Rec. Closure",
-    3 => "Rec. Reopening",
-    4 => "Reopened"
-  }
-
   STATUS_SORT_ORDER = {
     "New" => 0,
     "Rec. Reopening" => 1,
@@ -36,12 +28,11 @@ module ComplaintsHelper
     page == @pagy.series.last ? "Last page, page #{page}" : "Page #{page}"
   end
 
-  def status(complaint_attributes)
-    formatted_status = FORMATTED_STATUS[complaint_attributes[:status][:id]]
-    if complaint_attributes[:creationDate] > 1.week.ago && formatted_status == "In Progress"
-      "New"
-    else
-      formatted_status
-    end
+  def sort_date(date)
+    date.to_datetime.to_i
+  end
+
+  def sort_status(status_label)
+    STATUS_SORT_ORDER[status_label]
   end
 end

--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -9,10 +9,24 @@ class Complaint
     initialContactDate: "Initial contact from complaint"
   }.with_indifferent_access.freeze
 
+  FORMATTED_STATUS = {
+    0 => "In Progress",
+    1 => "Closed",
+    2 => "Rec. Closure",
+    3 => "Rec. Reopening",
+    4 => "Reopened"
+  }.with_indifferent_access.freeze
+
   def initialize(hses_complaint)
     @id = hses_complaint[:id]
     @attributes = hses_complaint[:attributes].with_indifferent_access
     @links = hses_complaint[:links].with_indifferent_access
+  end
+
+  def creation_date
+    Date.parse(attributes[:creationDate])
+  rescue
+    nil
   end
 
   def formatted_creation_date
@@ -35,6 +49,14 @@ class Complaint
     attributes[:grantee]
   end
 
+  def has_monitoring_review?
+    @has_monitoring_review ||= IssueMonitoringReview.where(issue_id: id).any?
+  end
+
+  def has_tta_report?
+    @has_tta_report ||= IssueTtaReport.where(issue_id: id).any?
+  end
+
   def overdue?
     due_date? && due_date.before?(Date.current)
   end
@@ -55,12 +77,18 @@ class Complaint
     links[:html]
   end
 
+  def new?
+    # status_id 0 maps to "Open" label in HSES response
+    creation_date > 1.week.ago && status_id == 0
+  end
+
   def priority
     attributes[:priority][:label]
   end
 
   def status
-    attributes[:status][:label]
+    # we are changing to our own labels rather than the ones in HSES
+    new? ? "New" : FORMATTED_STATUS[status_id]
   end
 
   def summary
@@ -83,12 +111,6 @@ class Complaint
     due_date&.strftime("%m/%d/%Y")
   end
 
-  def creation_date
-    Date.parse(attributes[:creationDate])
-  rescue
-    nil
-  end
-
   def issue_last_updated
     Date.parse(attributes[:issueLastUpdated])
   rescue
@@ -97,5 +119,9 @@ class Complaint
 
   def relative_time_til_due
     (Date.current...due_date).count
+  end
+
+  def status_id
+    attributes[:status][:id]
   end
 end

--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -15,7 +15,7 @@ class Complaint
     2 => "Rec. Closure",
     3 => "Rec. Reopening",
     4 => "Reopened"
-  }.with_indifferent_access.freeze
+  }.freeze
 
   def initialize(hses_complaint)
     @id = hses_complaint[:id]

--- a/app/views/complaints/_complaints_table.html.erb
+++ b/app/views/complaints/_complaints_table.html.erb
@@ -16,7 +16,7 @@
   </thead>
   <tbody>
   <% @complaints.each do |complaint| %>
-    <%= render "complaints/complaints_table_detail", complaint: complaint %>
+    <%= render "complaints/complaints_table_detail", complaint_data: complaint %>
   <% end %>
   </tbody>
 </table>

--- a/app/views/complaints/_complaints_table_detail.html.erb
+++ b/app/views/complaints/_complaints_table_detail.html.erb
@@ -1,22 +1,23 @@
+<% complaint = Complaint.new(complaint_data) %>
+
 <tr>
-  <% formatted_status = status(complaint[:attributes]) %>
   <th scope="row" role="rowheader">
-    <span class="<%= formatted_status == "New" ? "text-bold" : "" %>">
-      <%= link_to complaint[:id], complaint_path(complaint[:id]), class: "usa-link" %>
+    <span class="<%= complaint.new? ? "text-bold" : "" %>">
+      <%= link_to complaint.id, complaint_path(complaint.id), class: "usa-link" %>
     </span>
   </th>
   <td
-    data-sort-value="<%= DateTime.parse(complaint[:attributes][:creationDate]).to_i %>"
+    data-sort-value="<%= sort_date(complaint.creation_date) %>"
   >
-    <%= DateTime.parse(complaint[:attributes][:creationDate]).strftime("%m/%d/%Y") %>
+    <%= complaint.formatted_creation_date %>
   </td>
   <td
-    data-sort-value="<%= ComplaintsHelper::STATUS_SORT_ORDER[formatted_status] %>"
+    data-sort-value="<%= sort_status(complaint.status) %>"
   >
-    <%= formatted_status %>
+    <%= complaint.status %>
   </td>
-  <td><%= complaint[:attributes][:grantee] %></td>
-  <td><%= truncate(complaint[:attributes][:summary]) %></td>
-  <td> TBD </td>
-  <td> TBD </td>
+  <td><%= complaint.grantee %></td>
+  <td><%= truncate(complaint.summary) %></td>
+  <td><%= "Yes" if complaint.has_tta_report? %></td>
+  <td><%= "Yes" if complaint.has_monitoring_review?%></td>
 </tr>

--- a/app/views/complaints/show.html.erb
+++ b/app/views/complaints/show.html.erb
@@ -57,7 +57,7 @@
     <div class="grid-col-8">
       <div class="summary-section summary-body">
         <h2 class="ct-section-divider ct-timeline__two-part-container">
-          <%= status(@complaint.attributes) %>
+          <%= @complaint.status %>
           <span class="ct-timeline__date">
             <% if !@complaint.due_date? %>
               No Due Date

--- a/spec/helpers/complaints_helper_spec.rb
+++ b/spec/helpers/complaints_helper_spec.rb
@@ -25,39 +25,17 @@ RSpec.describe ComplaintsHelper, type: :helper do
     end
   end
 
-  describe "#status" do
-    describe "a complaint that is less than a week old" do
-      let(:complaint) { {status: {id: 0}, creationDate: 1.day.ago} }
-
-      describe "an open complaint" do
-        it "returns 'New' as the formatted status" do
-          expect(status(complaint)).to eq "New"
-        end
-      end
-
-      describe "a complaint that is not open" do
-        it "returns the formatted status of the complaint's status " do
-          complaint[:status] = {id: 3}
-          expect(status(complaint)).to eq ComplaintsHelper::FORMATTED_STATUS[3]
-        end
-      end
+  describe "#sort_status" do
+    it "sorts New complaints first" do
+      expect(sort_status("New")).to eq 0
     end
 
-    describe "a complaint that is more than a week old" do
-      let(:complaint) { {status: {id: 0}, creationDate: 1.month.ago} }
+    it "sorts In Progress complaints in the middle" do
+      expect(sort_status("In Progress")).to eq 3
+    end
 
-      describe "an open complaint" do
-        it "returns 'In Progress' as the formatted status" do
-          expect(status(complaint)).to eq "In Progress"
-        end
-      end
-
-      describe "a complaint that is not open" do
-        it "returns the formatted status of the complaint's status " do
-          complaint[:status] = {id: 2}
-          expect(status(complaint)).to eq ComplaintsHelper::FORMATTED_STATUS[2]
-        end
-      end
+    it "sorts Closed complaints last" do
+      expect(sort_status("Closed")).to eq 5
     end
   end
 end

--- a/spec/models/complaint_spec.rb
+++ b/spec/models/complaint_spec.rb
@@ -30,6 +30,32 @@ RSpec.describe Complaint do
     end
   end
 
+  describe "#creation_date" do
+    context "when provided string with valid date" do
+      it "returns date object" do
+        expect(subject.creation_date).to be_a Date
+      end
+    end
+    context "when no date provided" do
+      before { subject.attributes[:creationDate] = nil }
+      it "returns nil" do
+        expect(subject.creation_date).to be_nil
+      end
+    end
+  end
+
+  describe "#formatted_creation_date" do
+    it "returns mm/dd/yyyy" do
+      expect(subject.formatted_creation_date).to match(/\d{2}\/\d{2}\/\d{4}/)
+    end
+  end
+
+  describe "#formatted_issue_last_updated" do
+    it "returns mm/dd/yyyy" do
+      expect(subject.formatted_creation_date).to match(/\d{2}\/\d{2}\/\d{4}/)
+    end
+  end
+
   # TODO: test for missing attribute
   describe "#grantee" do
     it "delegates to the attributes" do
@@ -49,6 +75,71 @@ RSpec.describe Complaint do
 
       it "returns false" do
         expect(subject.due_date?).to be false
+      end
+    end
+  end
+
+  describe "#has_monitoring_review?" do
+    context "has associated review" do
+      it "returns true" do
+        allow(IssueMonitoringReview).to receive(:where).and_return([1])
+        expect(subject.has_monitoring_review?).to be true
+      end
+    end
+
+    context "does not have associated review" do
+      it "returns false" do
+        expect(subject.has_monitoring_review?).to be false
+      end
+    end
+  end
+
+  describe "#has_tta_report?" do
+    context "has associated report" do
+      it "returns true" do
+        allow(IssueTtaReport).to receive(:where).and_return([1])
+        expect(subject.has_tta_report?).to be true
+      end
+    end
+
+    context "does not have associated report" do
+      it "returns false" do
+        expect(subject.has_tta_report?).to be false
+      end
+    end
+  end
+
+  describe "#new?" do
+    context "complaint is less than a week old" do
+      context "an open complaint" do
+        before { subject.attributes[:status][:id] = 0 }
+        it "is new" do
+          expect(subject.new?).to be true
+        end
+      end
+
+      context "a complaint that is not open" do
+        before { subject.attributes[:status][:id] = 5 }
+        it "is not new" do
+          expect(subject.new?).to be false
+        end
+      end
+    end
+
+    context "complaint is more than a week old" do
+      before { subject.attributes[:creationDate] = 8.days.before.to_date.iso8601 }
+      before { subject.attributes[:status][:id] = 0 }
+      context "an open complaint" do
+        it "is not new" do
+          expect(subject.new?).to be false
+        end
+      end
+
+      context "a complaint that is not open" do
+        before { subject.attributes[:status][:id] = 5 }
+        it "is not new" do
+          expect(subject.new?).to be false
+        end
       end
     end
   end
@@ -142,6 +233,38 @@ RSpec.describe Complaint do
         expect(subject.relative_due_date_html).to eq(
           "<span>Due in 12 days (#{strftime})</span>"
         )
+      end
+    end
+  end
+
+  describe "#status" do
+    context "a complaint that is less than a week old and open" do
+      before { subject.attributes[:creationDate] = 5.days.before.to_date.iso8601 }
+      before { subject.attributes[:status][:id] = 0 }
+      it "returns 'New'" do
+        expect(subject.status).to eq "New"
+      end
+    end
+
+    context "a complaint that is more than a week old and open" do
+      before { subject.attributes[:creationDate] = 8.days.before.to_date.iso8601 }
+      before { subject.attributes[:status][:id] = 0 }
+      it "returns 'In Progress'" do
+        expect(subject.status).to eq "In Progress"
+      end
+    end
+
+    context "a complaint that is not open" do
+      before { subject.attributes[:status][:id] = 1 }
+      it "returns 'Closed'" do
+        expect(subject.status).to eq "Closed"
+      end
+    end
+
+    context "a complaint that is recommended for closure" do
+      before { subject.attributes[:status][:id] = 2 }
+      it "returns 'Rec. Closure'" do
+        expect(subject.status).to eq "Rec. Closure"
       end
     end
   end

--- a/spec/models/complaint_spec.rb
+++ b/spec/models/complaint_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Complaint do
         expect(subject.creation_date).to be_a Date
       end
     end
+
     context "when no date provided" do
       before { subject.attributes[:creationDate] = nil }
       it "returns nil" do
@@ -113,6 +114,7 @@ RSpec.describe Complaint do
     context "complaint is less than a week old" do
       context "an open complaint" do
         before { subject.attributes[:status][:id] = 0 }
+
         it "is new" do
           expect(subject.new?).to be true
         end
@@ -120,6 +122,7 @@ RSpec.describe Complaint do
 
       context "a complaint that is not open" do
         before { subject.attributes[:status][:id] = 5 }
+
         it "is not new" do
           expect(subject.new?).to be false
         end
@@ -129,6 +132,7 @@ RSpec.describe Complaint do
     context "complaint is more than a week old" do
       before { subject.attributes[:creationDate] = 8.days.before.to_date.iso8601 }
       before { subject.attributes[:status][:id] = 0 }
+
       context "an open complaint" do
         it "is not new" do
           expect(subject.new?).to be false
@@ -137,6 +141,7 @@ RSpec.describe Complaint do
 
       context "a complaint that is not open" do
         before { subject.attributes[:status][:id] = 5 }
+
         it "is not new" do
           expect(subject.new?).to be false
         end
@@ -241,6 +246,7 @@ RSpec.describe Complaint do
     context "a complaint that is less than a week old and open" do
       before { subject.attributes[:creationDate] = 5.days.before.to_date.iso8601 }
       before { subject.attributes[:status][:id] = 0 }
+
       it "returns 'New'" do
         expect(subject.status).to eq "New"
       end
@@ -249,6 +255,7 @@ RSpec.describe Complaint do
     context "a complaint that is more than a week old and open" do
       before { subject.attributes[:creationDate] = 8.days.before.to_date.iso8601 }
       before { subject.attributes[:status][:id] = 0 }
+
       it "returns 'In Progress'" do
         expect(subject.status).to eq "In Progress"
       end
@@ -256,6 +263,7 @@ RSpec.describe Complaint do
 
     context "a complaint that is not open" do
       before { subject.attributes[:status][:id] = 1 }
+
       it "returns 'Closed'" do
         expect(subject.status).to eq "Closed"
       end
@@ -263,6 +271,7 @@ RSpec.describe Complaint do
 
     context "a complaint that is recommended for closure" do
       before { subject.attributes[:status][:id] = 2 }
+
       it "returns 'Rec. Closure'" do
         expect(subject.status).to eq "Rec. Closure"
       end

--- a/spec/models/monitoring_review_spec.rb
+++ b/spec/models/monitoring_review_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe MonitoringReview, type: :model do
   describe "#complete?" do
     context "review has a status of Complete" do
       it "is complete" do
-        subject.stub(:status).and_return("Complete")
+        expect(subject).to receive(:status).and_return("Complete")
         expect(subject.complete?).to be true
       end
     end
 
     context "review has a status of In Progress" do
       it "is not complete" do
-        subject.stub(:status).and_return("In Progress")
+        expect(subject).to receive(:status).and_return("In Progress")
         expect(subject.complete?).to be false
       end
     end

--- a/spec/views/complaints/_complaints_table_detail.html.erb_spec.rb
+++ b/spec/views/complaints/_complaints_table_detail.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "rendering complaints table" do
       complaint[:attributes][:status] = {id: 0}
       complaint[:id] = "12345"
 
-      render partial: "complaints/complaints_table_detail", locals: {complaint: complaint}
+      render partial: "complaints/complaints_table_detail", locals: {complaint_data: complaint}
       expect(rendered.squish).to match '<span class="text-bold"> <a class="usa-link" href="/complaints/12345">12345</a> </span>'
     end
   end
@@ -19,7 +19,7 @@ RSpec.describe "rendering complaints table" do
       complaint[:attributes][:creationDate] = 1.month.ago.strftime("%FT%TZ")
       complaint[:id] = "12345"
 
-      render partial: "complaints/complaints_table_detail", locals: {complaint: complaint}
+      render partial: "complaints/complaints_table_detail", locals: {complaint_data: complaint}
       expect(rendered.squish).to match '<span class=""> <a class="usa-link" href="/complaints/12345">12345</a> </span>'
     end
   end


### PR DESCRIPTION
## Description of change

I went to add "Yes" to the RAN and TTA columns of the index page's complaint table, when I decided it would be much easier if the Complaint model itself knew whether it had any RAN / TTA activity.  Then I realized heck, it would be great if it knew if it was a new complaint, and if it could return its status already formatted and then I kinda just kept redoing things....

- moves formatted status behavior out of helpers, simplifies views
- adds methods for `new?`, `has_monitoring_review?`, and `has_tta_report?`

In terms of the RAN / TTA issue, this is what I've got:

![image](https://user-images.githubusercontent.com/2480492/139876196-92214019-2baf-4228-b3c5-945850f3fd0b.png)

## Acceptance Criteria

- are these helpful and logical changes?
- nothing got broken along the way (like status formatting / sorting)
- RAN and TTA have "Yes" if the issue is linked to something

## How to test

Start the app, navigate to a complaint page and add a TTA and / or RAN link. Now on the complaints page, you should see "Yes" in the appropriate column.

## Issue(s)

* closes https://github.com/OHS-Hosting-Infrastructure/complaint-tracker/issues/221


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
