### PR TITLE
Add sort variable to pagination links

### DIFF
--- a/app/helpers/complaints_helper.rb
+++ b/app/helpers/complaints_helper.rb
@@ -10,14 +10,14 @@ module ComplaintsHelper
     "Closed" => 5
   }
 
-  def page_link(page, current: false)
+  def page_link(page, path_args, current: false)
     options = {
       class: page_link_class(current),
       "aria-label": page_link_label(page)
     }
     options["aria-current"] = "page" if current
 
-    link_to page, complaints_path(page: page), options
+    link_to page, complaints_path(path_args.merge(page: page)), options
   end
 
   def page_link_class(current)

--- a/app/views/complaints/_complaints_table.html.erb
+++ b/app/views/complaints/_complaints_table.html.erb
@@ -29,6 +29,6 @@
   <!-- this content will change when sort changes -->
 </div>
 
-<%= render partial: 'complaints/pagination', locals: {pagy: @pagy} %>
+<%= render partial: 'complaints/pagination', locals: {pagy: @pagy, path_args: {sort: @sort}} %>
 
 <%= javascript_pack_tag 'complaint-sort' %>

--- a/app/views/complaints/_pagination.html.erb
+++ b/app/views/complaints/_pagination.html.erb
@@ -7,7 +7,7 @@
       <%# previous %>
       <% if pagy.prev %>
         <li class="usa-pagination__item usa-pagination__arrow">
-          <%= link_to complaints_path(page: pagy.prev),
+          <%= link_to complaints_path(path_args.merge(page: pagy.prev)),
             class: "usa-pagination__link usa-pagination__previous-page",
             "aria-label": "Previous page" do
           %>
@@ -32,7 +32,7 @@
           </li>
         <% else %>
           <li class="usa-pagination__item usa-pagination__page-no">
-            <%= page_link(item, current: !!item.is_a?(String)) %>
+            <%= page_link(item, path_args, current: !!item.is_a?(String)) %>
           </li>
         <% end %>
       <% end %>
@@ -40,7 +40,7 @@
       <%# next %>
       <% if pagy.next %>
         <li class="usa-pagination__item usa-pagination__arrow">
-          <%= link_to complaints_path(page: pagy.next),
+          <%= link_to complaints_path(path_args.merge(page: pagy.next)),
             class: "usa-pagination__link usa-pagination__next-page",
             "aria-label": "Next page" do
           %>

--- a/spec/helpers/complaints_helper_spec.rb
+++ b/spec/helpers/complaints_helper_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe ComplaintsHelper, type: :helper do
     context "when the link is not the current page" do
       it "returns link without aria-current or usa-current class" do
         @pagy = Pagy.new(count: 26, page: 2)
-        expect(page_link(1)).to eq '<a class="usa-pagination__button" aria-label="Page 1" href="/complaints?page=1">1</a>'
+        expect(page_link(1, {sort: nil})).to eq '<a class="usa-pagination__button" aria-label="Page 1" href="/complaints?page=1">1</a>'
       end
     end
 
     context "when the link is the current page" do
       it "returns link with aria-current and usa-current class" do
         @pagy = Pagy.new(count: 26, page: 2)
-        expect(page_link(2, current: true)).to eq '<a class="usa-pagination__button usa-current" aria-label="Page 2" aria-current="page" href="/complaints?page=2">2</a>'
+        expect(page_link(2, {sort: nil}, current: true)).to eq '<a class="usa-pagination__button usa-current" aria-label="Page 2" aria-current="page" href="/complaints?page=2">2</a>'
       end
     end
 
@@ -20,7 +20,14 @@ RSpec.describe ComplaintsHelper, type: :helper do
       it "aria-label includes 'Last page'" do
         @page_total = 5
         @pagy = Pagy.new(count: 101, page: 1)
-        expect(page_link(5)).to eq '<a class="usa-pagination__button" aria-label="Last page, page 5" href="/complaints?page=5">5</a>'
+        expect(page_link(5, {sort: nil})).to eq '<a class="usa-pagination__button" aria-label="Last page, page 5" href="/complaints?page=5">5</a>'
+      end
+    end
+
+    context "when sort is set" do
+      it "returns link with the sort parameter set" do
+        @pagy = Pagy.new(count: 26, page: 2)
+        expect(page_link(1, {sort: "creationDate"})).to eq '<a class="usa-pagination__button" aria-label="Page 1" href="/complaints?page=1&amp;sort=creationDate">1</a>'
       end
     end
   end

--- a/spec/views/complaints/_pagination.erb_spec.rb
+++ b/spec/views/complaints/_pagination.erb_spec.rb
@@ -10,6 +10,20 @@ RSpec.describe "rendering pagination" do
       expect(rendered).to include '<a class="usa-pagination__button usa-current" aria-label="Page 1" aria-current="page" href="/complaints?page=1">1</a>'
     end
 
+    it "generates proper link for previous page" do
+      @pagy = Pagy.new(count: 250, page: 2)
+
+      render partial: "complaints/pagination", locals: {pagy: @pagy, path_args: {sort: "creationDate"}}
+      expect(rendered).to include '<a class="usa-pagination__link usa-pagination__previous-page" aria-label="Previous page" href="/complaints?page=1&amp;sort=creationDate">'
+    end
+
+    it "generates proper link for next page" do
+      @pagy = Pagy.new(count: 250)
+
+      render partial: "complaints/pagination", locals: {pagy: @pagy, path_args: {sort: "creationDate"}}
+      expect(rendered).to include '<a class="usa-pagination__link usa-pagination__next-page" aria-label="Next page" href="/complaints?page=2&amp;sort=creationDate">'
+    end
+
     it "selects appropriate page" do
       @pagy = Pagy.new(count: 250, page: 5)
 

--- a/spec/views/complaints/_pagination.erb_spec.rb
+++ b/spec/views/complaints/_pagination.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "rendering pagination" do
     it "returns pagination and selects first page if none set" do
       @pagy = Pagy.new(count: 250)
 
-      render partial: "complaints/pagination", locals: {pagy: @pagy}
+      render partial: "complaints/pagination", locals: {pagy: @pagy, path_args: {}}
       expect(rendered).to include '<nav aria-label="pagination" class="usa-pagination">'
       expect(rendered).to include '<a class="usa-pagination__button usa-current" aria-label="Page 1" aria-current="page" href="/complaints?page=1">1</a>'
     end
@@ -13,7 +13,7 @@ RSpec.describe "rendering pagination" do
     it "selects appropriate page" do
       @pagy = Pagy.new(count: 250, page: 5)
 
-      render partial: "complaints/pagination", locals: {pagy: @pagy}
+      render partial: "complaints/pagination", locals: {pagy: @pagy, path_args: {}}
       expect(rendered).to include '<a class="usa-pagination__button usa-current" aria-label="Page 5" aria-current="page" href="/complaints?page=5">5</a>'
     end
   end
@@ -22,7 +22,7 @@ RSpec.describe "rendering pagination" do
     it "has no pagination" do
       @pagy = Pagy.new(count: 25)
 
-      render partial: "complaints/pagination", locals: {pagy: @pagy}
+      render partial: "complaints/pagination", locals: {pagy: @pagy, path_args: {}}
       expect(rendered).not_to include '<nav aria-label="pagination" class="usa-pagination">'
     end
   end


### PR DESCRIPTION
## Description of change

Adds sort to the pagination links so we can access the second page of oldest issues

## Acceptance Criteria

Sort issues by oldest first
Click on link to page 2
Should see second-oldest page of issues

## Issue(s)

* closes #229 


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [x] Meets issue criteria
- [x] Code is meaningfully tested
- [x] Meets accessibility standards (WCAG 2.1 Levels A, AA)

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
