### PR TITLE
adds link for grantee on complaint detail page

### DIFF
--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -23,6 +23,10 @@ class Complaint
     @links = hses_complaint[:links].with_indifferent_access
   end
 
+  def agency_id
+    attributes[:agencyId]
+  end
+
   def creation_date
     Date.parse(attributes[:creationDate])
   rescue

--- a/app/views/complaints/show.html.erb
+++ b/app/views/complaints/show.html.erb
@@ -13,7 +13,7 @@
         <div class="ct-section-divider">
           <h2>Summary</h2>
           <p>
-            <strong><%= @complaint.grantee %>:</strong>
+            <strong><%= link_to @complaint.grantee, grantee_path(id: @complaint.agency_id) %>:</strong>
             <%= @complaint.summary %>
           </p>
         </div>

--- a/spec/views/complaints/show.html.erb_spec.rb
+++ b/spec/views/complaints/show.html.erb_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "complaints/show.html.erb", type: :view do
   let(:complaint) { Complaint.new(Api::FakeData::Complaint.new.data) }
   let(:issue_number) { complaint.id }
+  let(:agency_id) { complaint.agency_id }
   let(:grantee_name) { complaint.grantee }
   let(:summary) { complaint.summary }
   let(:timeline) { Timeline.new(complaint.attributes, [], []) }
@@ -20,8 +21,8 @@ RSpec.describe "complaints/show.html.erb", type: :view do
       expect(rendered).to match "<h1>HSES Issue ##{issue_number}</h1>"
     end
 
-    it "displays the grantee name" do
-      expect(rendered).to match CGI.escapeHTML(grantee_name)
+    it "displays the grantee name and link" do
+      expect(rendered).to match "<strong><a href=\"/grantees/#{agency_id}\">#{CGI.escapeHTML(grantee_name)}</a>:</strong>"
     end
 
     it "displays the issue text" do


### PR DESCRIPTION
## Description of change

Adds link to grantee name on complaint detail page for grantee detail page.

NOTE: uses agencyId, not grantNumber for the identifier in the URL

## Acceptance Criteria

- is a link
- works

## How to test

Navigate to a complaint detail page, click the grantee name in the summary box, go to a real place.
I recommend testing this with real data, but fake data should at least get you somewhere.

## Issue(s)

* closes #232 


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
