### PR TITLE
Edit ran link

### DIFF
--- a/app/controllers/issue_monitoring_reviews_controller.rb
+++ b/app/controllers/issue_monitoring_reviews_controller.rb
@@ -28,6 +28,19 @@ class IssueMonitoringReviewsController < ApplicationController
     redirect_back fallback_location: complaint_path(issue_id)
   end
 
+  def update
+    @issue_monitoring_review = IssueMonitoringReview.find(params[:id])
+
+    respond_to do |format|
+      if @issue_monitoring_review.update(review_id: review_id, access_token: hses_access_token)
+        format.js { render inline: "location.reload(true);" }
+      else
+        format.js { render inline: "alert('there was an error changing the id of the RAN review');" }
+        # format.js { render "update_errors" }
+      end
+    end
+  end
+
   private
 
   def issue_id

--- a/app/controllers/issue_monitoring_reviews_controller.rb
+++ b/app/controllers/issue_monitoring_reviews_controller.rb
@@ -13,8 +13,7 @@ class IssueMonitoringReviewsController < ApplicationController
         format.js { render inline: "location.reload(true);" }
       else
         format.js { render inline: "alert('there was an error linking to a RAN review');" }
-        # TODO implement when working on error handling
-        # format.js { render "create_errors" }
+        # TODO implement create_errors when working on error handling
       end
     end
   end
@@ -36,7 +35,7 @@ class IssueMonitoringReviewsController < ApplicationController
         format.js { render inline: "location.reload(true);" }
       else
         format.js { render inline: "alert('there was an error changing the id of the RAN review');" }
-        # format.js { render "update_errors" }
+        # TODO implement update_errors when working on error handling
       end
     end
   end

--- a/app/javascript/packs/complaint-links.js
+++ b/app/javascript/packs/complaint-links.js
@@ -50,40 +50,41 @@ document.querySelector("#js-close-monitoring-form").addEventListener('click', ev
   clearFormValue("#monitoring-review-id")
 })
 
+// Edit form
 
-document.querySelectorAll(".js-edit-tta").forEach((el) => {
+document.querySelectorAll(".js-edit-link").forEach((el) => {
   el.addEventListener('click', event => {
     event.preventDefault()
 
     // hide details
-    const id = event.currentTarget.dataset.id
-    document.querySelector(`#tta-activity-show-${id}`).classList.add("display-none")
+    const { id, activityType } = event.currentTarget.dataset
+    document.querySelector(`#${activityType}-activity-show-${id}`).classList.add("display-none")
     // show form
-    const form = document.querySelector(`#edit-tta-activity-${id}`)
+    const form = document.querySelector(`#edit-${activityType}-activity-${id}`)
     form.classList.remove("display-none")
     form.querySelector("input[type='text']").focus()
   })
 })
 
-document.querySelectorAll(".js-close-edit-tta").forEach((el) => {
+document.querySelectorAll(".js-close-edit-link").forEach((el) => {
   el.addEventListener('click', event => {
     event.preventDefault()
 
-    const id = event.currentTarget.dataset.id
+    const { id, activityType } = event.currentTarget.dataset
     // hide form
-    closeForm(`#edit-tta-activity-${id}`)
+    closeForm(`#edit-${activityType}-activity-${id}`)
     // show detail
-    document.querySelector(`#tta-activity-show-${id}`).classList.remove("display-none")
+    document.querySelector(`#${activityType}-activity-show-${id}`).classList.remove("display-none")
   })
 })
 
-// Unlink form for TTA and Monitoring
+// Unlink form
 
 document.querySelectorAll(".js-open-unlink-modal").forEach((el) => {
   el.addEventListener('click', event => {
     // note: id here refers to monitoring's review id or a TTA issue's display_id
     const { id, inputField } = event.currentTarget.dataset
-    const hiddenInput = document.querySelector("#hidden-"+inputField)
+    const hiddenInput = document.querySelector(`#hidden-${inputField}`)
     // add id to hidden input form
     hiddenInput.value = id
   })

--- a/app/views/complaints/_issue_monitoring_review.html.erb
+++ b/app/views/complaints/_issue_monitoring_review.html.erb
@@ -1,6 +1,12 @@
-<div class="ct-tta-divider display-flex flex-justify" id="monitoring-activity-show-<%= issue_monitoring_review.id %>">
+<div class="ct-monitoring-divider display-flex flex-justify" id="monitoring-activity-show-<%= issue_monitoring_review.id %>">
   <div><%= issue_monitoring_review.review_id %></div>
   <div>
+    <%= button_tag image_pack_tag("media/usa-icons/edit.svg", alt: "Edit RAN Review ID"),
+      class: "ct-link-icon usa-button--unstyled js-edit-link",
+      "aria-label": "Edit RAN Review ID",
+      "data-id": issue_monitoring_review.id,
+      "data-activity-type": "monitoring"
+    %>
     <%=  link_to image_pack_tag("media/usa-icons/link_off.svg", alt: "Unlink RAN ID"),
       "#unlink-modal-monitoring",
       class: "ct-link-icon usa-button--unstyled js-open-unlink-modal",
@@ -11,4 +17,8 @@
       "data-input-field": "monitoring_review_id"
     %>
   </div>
+</div>
+
+<div class="display-none" id="edit-monitoring-activity-<%= issue_monitoring_review.id %>">
+  <%= render "monitoring_edit_review", issue_monitoring_review: issue_monitoring_review %>
 </div>

--- a/app/views/complaints/_issue_tta_report.html.erb
+++ b/app/views/complaints/_issue_tta_report.html.erb
@@ -1,10 +1,11 @@
 <div class="ct-tta-divider display-flex flex-justify" id="tta-activity-show-<%= issue_tta_report.id %>">
   <div><%= issue_tta_report.tta_report_display_id %></div>
   <div>
-    <%= button_tag image_pack_tag("media/usa-icons/edit.svg", alt: "Edit Display ID"),
-      class: "ct-link-icon usa-button--unstyled js-edit-tta",
-      "aria-label": "Edit Display ID",
-      "data-id": issue_tta_report.id
+    <%= button_tag image_pack_tag("media/usa-icons/edit.svg", alt: "Edit Activity Report Display ID"),
+      class: "ct-link-icon usa-button--unstyled js-edit-link",
+      "aria-label": "Edit Activity Report Display ID",
+      "data-id": issue_tta_report.id,
+      "data-activity-type": "tta"
     %>
     <%=  link_to image_pack_tag("media/usa-icons/link_off.svg", alt: "Unlink Display ID"),
       "#unlink-modal-tta",
@@ -17,6 +18,7 @@
     %>
   </div>
 </div>
+
 <div class="display-none" id="edit-tta-activity-<%= issue_tta_report.id %>">
   <%= render "tta_edit_activity_report", issue_tta_report: issue_tta_report %>
 </div>

--- a/app/views/complaints/_monitoring_edit_review.html.erb
+++ b/app/views/complaints/_monitoring_edit_review.html.erb
@@ -1,0 +1,24 @@
+<div class="ct-section-divider">
+  <% review_id = issue_monitoring_review.review_id %>
+  <p>
+    <div class="display-flex flex-justify margin-bottom-2">
+      <span> RAN Review ID</span>
+      <%= button_to "Cancel", ".js-add-monitoring-review",
+        class: "usa-link usa-button--unstyled js-close-edit-link",
+        "data-id": issue_monitoring_review.id,
+        "data-activity-type": "monitoring"
+      %>
+    </div>
+    <div>
+      <%= form_with url: issue_monitoring_review_path(issue_monitoring_review), local: false, method: "put", class: "usa-search display-flex" do %>
+        <%= hidden_field_tag(:issue_id_monitoring, @complaint.id) %>
+        <div class="usa-form-group">
+          <%= label_tag "monitoring-edit-review-id", "Monitoring RAN ID", class: "usa-sr-only  monitoring-edit-review-label" %>
+          <span class="usa-error-message"></span>
+          <%= text_field_tag :monitoring_review_id, review_id, id: review_id, "aria-describedBy": "monitoring-edit-review-label" %>
+          <%= submit_tag "Save", class: "usa-button usa-search__submit-text" %>
+        </div>
+      <% end %>
+    </div>
+  </p>
+</div>

--- a/app/views/complaints/_tta_edit_activity_report.html.erb
+++ b/app/views/complaints/_tta_edit_activity_report.html.erb
@@ -4,8 +4,9 @@
     <div class="display-flex flex-justify margin-bottom-2">
       <span> Activity Report ID</span>
       <%= button_to "Cancel", ".js-add-tta-report",
-        class: "usa-link usa-button--unstyled js-close-edit-tta",
-        "data-id": issue_tta_report.id
+        class: "usa-link usa-button--unstyled js-close-edit-link",
+        "data-id": issue_tta_report.id,
+        "data-activity-type": "tta"
       %>
     </div>
     <div>

--- a/app/views/complaints/show.html.erb
+++ b/app/views/complaints/show.html.erb
@@ -29,7 +29,7 @@
 
         <% if @issue_monitoring_reviews.present? %>
           <div>
-            <h3>RAN activity:</h3>
+            <h3>RAN Activity:</h3>
             <div>
               <%= render partial: "issue_monitoring_review", collection: @issue_monitoring_reviews %>
             </div>

--- a/app/views/complaints/show.html.erb
+++ b/app/views/complaints/show.html.erb
@@ -13,7 +13,7 @@
         <div class="ct-section-divider">
           <h2>Summary</h2>
           <p>
-            <strong><%= link_to @complaint.grantee, grantee_path(id: @complaint.agency_id) %>:</strong>
+            <strong><%= link_to @complaint.grantee, grantee_path(id: @complaint.agency_id), class: "usa-link" %>:</strong>
             <%= @complaint.summary %>
           </p>
         </div>

--- a/spec/features/complaints/monitoring_review_spec.rb
+++ b/spec/features/complaints/monitoring_review_spec.rb
@@ -49,8 +49,30 @@ RSpec.feature "Associating monitoring review", type: :feature do
       visit "complaints/#{complaint.id}"
     end
 
+    context "editing the associated review" do
+      it "can successfully edit a RAN review id" do
+        expect(page).to have_content "RAN Activity:\n#{test_id}\n"
+
+        find_button("Edit RAN Review ID").click
+        # fill_in "RAN review ID", with: "NEW-TEST-ID"
+        page.find("##{test_id}").fill_in with: "NEW-TEST-ID"
+        click_button "Save"
+
+        expect(page).to_not have_content "RAN Activity:\n#{test_id}\n"
+      end
+
+      it "can cancel out of editing a RAN review id" do
+        expect(page).to have_content "RAN Activity:\n#{test_id}\n"
+        find_button("Edit RAN Review ID").click
+        page.find("##{test_id}").fill_in with: "NEW-TEST-ID"
+        page.find("#edit-monitoring-activity-#{issue_monitoring_review.id} .js-close-edit-link").click
+
+        expect(page).to have_content "RAN Activity:\n#{test_id}\n"
+      end
+    end
+
     it "can unlink a monitoring review id" do
-      expect(page).to have_content "RAN activity:\n#{test_id}\n"
+      expect(page).to have_content "RAN Activity:\n#{test_id}\n"
       page.find("#monitoring-activity-show-#{issue_monitoring_review.id} .js-open-unlink-modal").click
       click_button "monitoring-unlink-submit"
 

--- a/spec/features/complaints/monitoring_review_spec.rb
+++ b/spec/features/complaints/monitoring_review_spec.rb
@@ -54,7 +54,6 @@ RSpec.feature "Associating monitoring review", type: :feature do
         expect(page).to have_content "RAN Activity:\n#{test_id}\n"
 
         find_button("Edit RAN Review ID").click
-        # fill_in "RAN review ID", with: "NEW-TEST-ID"
         page.find("##{test_id}").fill_in with: "NEW-TEST-ID"
         click_button "Save"
 

--- a/spec/features/complaints/tta_activity_report_spec.rb
+++ b/spec/features/complaints/tta_activity_report_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature "Associating TTA Activity Report", type: :feature do
       it "can successfully edit a TTA activity report display id" do
         expect(page).to have_content "TTA Activity:\n#{test_display_id}\n"
 
-        find_button("Edit Display ID").click
+        find_button("Edit Activity Report Display ID").click
         # fill_in "TTA report display ID", with: "R02-AR-14532"
         page.find("##{test_display_id}").fill_in with: "R02-AR-14532"
         click_button "Save"
@@ -107,9 +107,9 @@ RSpec.feature "Associating TTA Activity Report", type: :feature do
 
       it "can cancel out of editing a TTA activity report display id" do
         expect(page).to have_content "TTA Activity:\n#{test_display_id}\n"
-        find_button("Edit Display ID").click
+        find_button("Edit Activity Report Display ID").click
         page.find("##{test_display_id}").fill_in with: "RO2-AR-14532"
-        page.find("#edit-tta-activity-#{issue_tta_report.id} .js-close-edit-tta").click
+        page.find("#edit-tta-activity-#{issue_tta_report.id} .js-close-edit-link").click
 
         expect(page).to have_content "TTA Activity:\n#{test_display_id}\n"
       end

--- a/spec/features/complaints/tta_activity_report_spec.rb
+++ b/spec/features/complaints/tta_activity_report_spec.rb
@@ -98,7 +98,6 @@ RSpec.feature "Associating TTA Activity Report", type: :feature do
         expect(page).to have_content "TTA Activity:\n#{test_display_id}\n"
 
         find_button("Edit Activity Report Display ID").click
-        # fill_in "TTA report display ID", with: "R02-AR-14532"
         page.find("##{test_display_id}").fill_in with: "R02-AR-14532"
         click_button "Save"
 

--- a/spec/views/complaints/show.html.erb_spec.rb
+++ b/spec/views/complaints/show.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "complaints/show.html.erb", type: :view do
     end
 
     it "displays the grantee name and link" do
-      expect(rendered).to match "<strong><a href=\"/grantees/#{agency_id}\">#{CGI.escapeHTML(grantee_name)}</a>:</strong>"
+      expect(rendered).to match "<strong><a class=\"usa-link\" href=\"/grantees/#{agency_id}\">#{CGI.escapeHTML(grantee_name)}</a>:</strong>"
     end
 
     it "displays the issue text" do


### PR DESCRIPTION
## Description of change

Adds editing functionality to the monitoring link on a complaint detail page.  Ideal error functionality was not in this issue, but can be done as part of #207 if we get there.

## Acceptance Criteria

- can edit a linked review

## How to test

Go to a complaint detail page, choose an existing linked review (or add one if there isn't anything already), click the pencil icon, change the number, check that it saved correctly!

## Issue(s)

* closes #228 


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [X] Meets issue criteria
- [X] Code is meaningfully tested
- [X] Meets accessibility standards (WCAG 2.1 Levels A, AA)

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
