### PR TITLE
aligns "real" monitoring request with faked request

### DIFF
--- a/app/models/api/monitoring.rb
+++ b/app/models/api/monitoring.rb
@@ -2,16 +2,18 @@
 require "fake_api_response_wrapper"
 
 module Api::Monitoring
-  include FakeApiResponseWrapper
-  attr_accessor :id
+  class Review
+    include FakeApiResponseWrapper
+    attr_accessor :id
 
-  def initialize(id:, access_token:)
-    @id = id
-  end
+    def initialize(id:, access_token:)
+      @id = id
+    end
 
-  def request
-    details_response(
-      Api::FakeData::MonitoringReview.new(id: id).data
-    )
+    def request
+      details_response(
+        Api::FakeData::Review.new(id: id).data
+      )
+    end
   end
 end


### PR DESCRIPTION
## Description of change

We do not have an endpoint set up with IT-AMS to send actual monitoring requests, so currently requests should be relying on a fake review. Unfortunately, this class had drifted from the fake monitoring data. This commit lines up its class type and how it calls the fake data.

## Acceptance Criteria

Able to add a RAN review to a complaint detail page when using `CT_USE_REAL_API_DATA=true`

## How to test

See above

## Issue(s)

* part of #236 


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
