### PR TITLE
Add validation for Display Id format

### DIFF
--- a/app/models/tta_activity_report.rb
+++ b/app/models/tta_activity_report.rb
@@ -2,6 +2,7 @@ require "api_delegator"
 
 class TtaActivityReport
   include ActiveModel::Validations
+  validate :check_display_id_format
   validate :api_call_succeeded
 
   attr_accessor :access_token, :display_id
@@ -38,6 +39,7 @@ class TtaActivityReport
   private
 
   def api_call_succeeded
+    return unless errors.blank?
     errors.add(:base, tta_link_error_message) if activity_data.failed?
   end
 
@@ -55,6 +57,15 @@ class TtaActivityReport
 
   def api
     ApiDelegator.use("tta", "activity_report", display_id: display_id, access_token: access_token)
+  end
+
+  def check_display_id_format
+    # TODO: There are legacy display IDs in the system that may have a different format.
+    # If a user is attemping to use a legacy display ID, this may not work. Please update to ensure all
+    # possible display IDs will pass through correctly. (And/or fix on TTAHub Api side.)
+    unless display_id.match?(/^R\d{2}-AR-/)
+      errors.add(:base, "This doesn't look like a TTA Activity Report Display ID. Please double check the format.")
+    end
   end
 
   def tta_link_error_message

--- a/spec/features/complaints/tta_activity_report_spec.rb
+++ b/spec/features/complaints/tta_activity_report_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Associating TTA Activity Report", type: :feature do
       expires: true
     }
   }
-  let(:test_display_id) { "Test-Display-ID" }
+  let(:test_display_id) { "R12-AR-1234" }
 
   let!(:complaint) { Complaint.new(FakeIssues.instance.data.first) }
 

--- a/spec/models/api/fake_data/activity_report_spec.rb
+++ b/spec/models/api/fake_data/activity_report_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Api::FakeData::ActivityReport do
   describe "ActivityReport" do
-    let(:display_id) { "RO4-VQ-14661" }
+    let(:display_id) { "RO4-AR-14661" }
     let(:report) { Api::FakeData::ActivityReport.new(display_id: display_id) }
 
     describe "#init" do

--- a/spec/models/api/fake_data/tta_spec.rb
+++ b/spec/models/api/fake_data/tta_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::FakeData::Tta do
 
     describe "#request" do
       context "successful request" do
-        let(:display_id) { "RO4-VQ-14661" }
+        let(:display_id) { "RO4-AR-14661" }
 
         it "returns an activity report with the right display_id" do
           expect(subject.request.data[:attributes][:displayId]).to eq display_id

--- a/spec/models/timeline/tta_event_spec.rb
+++ b/spec/models/timeline/tta_event_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Timeline::TtaEvent do
   let(:date) { 1.day.ago.strftime("%F") }
-  let(:display_id) { "Test-Display-Name" }
+  let(:display_id) { "R12-AR-532413" }
   # just setting the start_date manually because we aren't triggering the before_validation callback
   let(:event_param) { IssueTtaReport.new tta_report_display_id: display_id, start_date: date }
   let(:tta_activity_report) { event_param.tta_activity_report }

--- a/spec/models/timeline_spec.rb
+++ b/spec/models/timeline_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Timeline do
-  let(:tta_display_id) { "First-Display-ID" }
-  let(:tta_display_id_2) { "Second-Display-ID" }
+  let(:tta_display_id) { "R09-AR-First-ID" }
+  let(:tta_display_id_2) { "R09-AR-Second-ID" }
   let(:review_id) { "First-Review-ID" }
   let(:review_id_2) { "Second-Review-ID" }
   let(:tta_activity_report) { IssueTtaReport.create tta_report_display_id: tta_display_id, issue_id: "1" }

--- a/spec/requests/issue_tta_reports_spec.rb
+++ b/spec/requests/issue_tta_reports_spec.rb
@@ -4,7 +4,7 @@ require "api_delegator"
 
 RSpec.describe "IssueTtaReports", type: :request do
   let(:complaint_id) { FakeIssues.instance.data.first[:id] }
-  let(:tta_display_id) { "RO4-VQ-14661" }
+  let(:tta_display_id) { "R04-AR-14661" }
   let(:user) {
     {
       name: "Request Spec",
@@ -79,6 +79,7 @@ RSpec.describe "IssueTtaReports", type: :request do
     end
 
     context "with an authorized user" do
+      let(:new_display_id) { "R04-AR-909090" }
       it "sends an API request to the tta system" do
         expect(ApiDelegator).to receive(:use)
           .with("tta", "activity_report", {display_id: tta_display_id, access_token: kind_of(HsesAccessToken)})
@@ -88,17 +89,17 @@ RSpec.describe "IssueTtaReports", type: :request do
 
       it "updates the IssueTtaReport object" do
         put issue_tta_report_path(issue_tta_report),
-          params: {tta_report_display_id: "new_display_id", issue_id_tta: complaint_id, format: :js}
+          params: {tta_report_display_id: new_display_id, issue_id_tta: complaint_id, format: :js}
 
         updated_report = IssueTtaReport.find(issue_tta_report.id)
-        expect(updated_report.tta_report_display_id).to eq "new_display_id"
+        expect(updated_report.tta_report_display_id).to eq new_display_id
       end
     end
   end
 
   describe "DELETE /issue_tta_report/unlink_report/:issue_id" do
     context "with an authorized user" do
-      let(:display_report_id) { "DisplayID " }
+      let(:display_report_id) { "R04-AR-909090" }
       let(:complaint_id) { FakeIssues.instance.data.first[:id] }
       let!(:issue_tta_report) do
         IssueTtaReport.create(
@@ -119,7 +120,7 @@ RSpec.describe "IssueTtaReports", type: :request do
       end
 
       describe "if a complaint has multiple TTA records" do
-        let(:second_display_id) { "SecondDisplayId" }
+        let(:second_display_id) { "R04-AR-11111" }
 
         before do
           post issue_tta_reports_path,


### PR DESCRIPTION
## Description of change
Adds some validation around the TTA Display ID format because TTAHub 500s if the display id is not in the expected format.

## Acceptance Criteria
When I input a TTA Activity Report Display ID that does not match the format `/^R/d{2}-AR-/`
I want an error that tells me it's a bad format
So I know what the problem is

## How to test

- [ ] Go to a complaint detail page.
- [ ] Try to link a TTA AR ID that is not in the `/^R/d{2}-AR-/` format
- [ ] You should get an error that says "This doesn't look like a TTA Activity Report Display ID. Please double check the format."
- [ ] Try to like a TTA AR ID that is in that format! You should get a different response depending on whether it's an ID you have access to or not.

## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
