### PR TITLE
removes unused portion of grantee page

### DIFF
--- a/app/views/grantees/show.html.erb
+++ b/app/views/grantees/show.html.erb
@@ -25,9 +25,6 @@
         <a href="<%= @grantee.hses_link %>" 
         class="usa-button width-full" target="_blank">Open in HSES</a>
       </div>
-      <div class="summary-section summary-body">
-        <h2>Open Issues</h2>
-      </div>
     </div>
     <div class="grid-col-8">
       <ul class="usa-list usa-list--unstyled">

--- a/spec/views/grantees/show.html.erb_spec.rb
+++ b/spec/views/grantees/show.html.erb_spec.rb
@@ -33,10 +33,6 @@ RSpec.describe "grantees/show", type: :view do
     end
   end
 
-  it "displays the open issues card" do
-    expect(rendered).to match "<h2>Open Issues</h2>"
-  end
-
   describe "complaints list" do
     it "displays the list" do
       expect(rendered).to match '<ul class=\"usa-list usa-list--unstyled\">'


### PR DESCRIPTION
we have not implemented this and will not be before the demo

## Description of change

removes the "Open Issues" summary section on the grantee detail page

![image](https://user-images.githubusercontent.com/2480492/142025673-b9cba18f-6d6c-41ba-b037-86cf0555d68c.png)


## Acceptance Criteria

## How to test

you can go look at the grantee page, and it should be gone

## Issue(s)

Not related to an issue


## Checklist

To be completed by the submitter:

<!-- Add details to each completed item -->
- [ ] Meets issue criteria
- [ ] Code is meaningfully tested
- [ ] Meets accessibility standards (WCAG 2.1 Levels A, AA)
- [ ] API Documentation updated
- [ ] Boundary diagram updated
- [ ] Logical Data Model updated
- [ ] [Architectural Decision Records](https://adr.github.io/) written for major infrastructure decisions

## To the Reviewer

This project is using [Conventional Comments](https://conventionalcomments.org/) to give structure
and context to PR comments. Please use these labels in your comments.

* **praise:**
* **nitpick:**
* **suggestion:**
* **issue:**
* **question:**
* **thought:**
* **chore:**
